### PR TITLE
Add same regex as client to address validation

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -71,3 +71,7 @@ export const BUS_API_EVENT = {
   PROJECT_FILE_UPLOADED: 'connect.project.fileUploaded',
   PROJECT_SPECIFICATION_MODIFIED: 'connect.project.specificationModified',
 };
+
+export const REGEX = {
+  URL: /^(http(s?):\/\/)?(www\.)?[a-zA-Z0-9\.\-\_]+(\.[a-zA-Z]{2,15})+(\:[0-9]{2,5})?(\/[a-zA-Z0-9\_\-\s\.\/\?\%\#\&\=]*)?$/,
+};

--- a/src/routes/projects/create.js
+++ b/src/routes/projects/create.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import Joi from 'joi';
 
 import models from '../../models';
-import { PROJECT_TYPE, PROJECT_MEMBER_ROLE, PROJECT_STATUS, USER_ROLE, EVENT } from '../../constants';
+import { PROJECT_TYPE, PROJECT_MEMBER_ROLE, PROJECT_STATUS, USER_ROLE, EVENT, REGEX } from '../../constants';
 import util from '../../util';
 import directProject from '../../services/directProject';
 
@@ -34,7 +34,7 @@ const createProjectValdiations = {
       }).allow(null),
       bookmarks: Joi.array().items(Joi.object().keys({
         title: Joi.string(),
-        address: Joi.string().regex(/^(http(s?):\/\/)?(www\.)?[a-zA-Z0-9\.\-\_]+(\.[a-zA-Z]{2,15})+(\:[0-9]{2,5})?(\/[a-zA-Z0-9\_\-\s\.\/\?\%\#\&\=]*)?$/),
+        address: Joi.string().regex(REGEX.URL),
       })).optional().allow(null),
       estimatedPrice: Joi.number().precision(2).positive().optional()
         .allow(null),

--- a/src/routes/projects/create.js
+++ b/src/routes/projects/create.js
@@ -34,7 +34,7 @@ const createProjectValdiations = {
       }).allow(null),
       bookmarks: Joi.array().items(Joi.object().keys({
         title: Joi.string(),
-        address: Joi.string(),
+        address: Joi.string().regex(/^(http(s?):\/\/)?(www\.)?[a-zA-Z0-9\.\-\_]+(\.[a-zA-Z]{2,15})+(\:[0-9]{2,5})?(\/[a-zA-Z0-9\_\-\s\.\/\?\%\#\&\=]*)?$/),
       })).optional().allow(null),
       estimatedPrice: Joi.number().precision(2).positive().optional()
         .allow(null),

--- a/src/routes/projects/update.js
+++ b/src/routes/projects/update.js
@@ -57,7 +57,7 @@ const updateProjectValdiations = {
       }).allow(null),
       bookmarks: Joi.array().items(Joi.object().keys({
         title: Joi.string(),
-        address: Joi.string(),
+        address: Joi.string().regex(/^(http(s?):\/\/)?(www\.)?[a-zA-Z0-9\.\-\_]+(\.[a-zA-Z]{2,15})+(\:[0-9]{2,5})?(\/[a-zA-Z0-9\_\-\s\.\/\?\%\#\&\=]*)?$/),
       })).optional().allow(null),
       type: Joi.any().valid(_.values(PROJECT_TYPE)),
       details: Joi.any(),

--- a/src/routes/projects/update.js
+++ b/src/routes/projects/update.js
@@ -11,6 +11,7 @@ import {
   PROJECT_MEMBER_ROLE,
   EVENT,
   USER_ROLE,
+  REGEX,
 } from '../../constants';
 import util from '../../util';
 import directProject from '../../services/directProject';
@@ -57,7 +58,7 @@ const updateProjectValdiations = {
       }).allow(null),
       bookmarks: Joi.array().items(Joi.object().keys({
         title: Joi.string(),
-        address: Joi.string().regex(/^(http(s?):\/\/)?(www\.)?[a-zA-Z0-9\.\-\_]+(\.[a-zA-Z]{2,15})+(\:[0-9]{2,5})?(\/[a-zA-Z0-9\_\-\s\.\/\?\%\#\&\=]*)?$/),
+        address: Joi.string().regex(REGEX.URL),
       })).optional().allow(null),
       type: Joi.any().valid(_.values(PROJECT_TYPE)),
       details: Joi.any(),


### PR DESCRIPTION
While we think of a better solution, add a regex to validate the urls
https://github.com/appirio-tech/connect-app/issues/1426
We can use joi to do that
https://github.com/hapijs/joi#example
For the regex see  
https://github.com/appirio-tech/react-components/blob/feature/connectv2/components/Formsy/index.js#L14