### PR TITLE
Some improvements for local deployment to work more out of the box.

### DIFF
--- a/config/sample.local.js
+++ b/config/sample.local.js
@@ -5,6 +5,7 @@ if (process.env.NODE_ENV === 'test') {
   config = require('./test.json');
 } else {
   config = {
+    identityServiceEndpoint: "http://dockerhost:3001/",
     authSecret: 'secret',
     authDomain: 'topcoder-dev.com',
     logLevel: 'debug',
@@ -14,9 +15,9 @@ if (process.env.NODE_ENV === 'test') {
     fileServiceEndpoint: 'https://api.topcoder-dev.com/v3/files/',
     directProjectServiceEndpoint: 'https://api.topcoder-dev.com/v3/direct',
     connectProjectsUrl: 'https://connect.topcoder-dev.com/projects/',
-    memberServiceEndpoint: 'http://dockerhost:3001/members',
+    memberServiceEndpoint: 'http://dockerhost:3001/v3/members',
     dbConfig: {
-      masterUrl: 'postgres://coder:mysecretpassword@dockerhost:54321/projectsdb',
+      masterUrl: 'postgres://coder:mysecretpassword@dockerhost:5432/projectsdb',
       maxPoolSize: 50,
       minPoolSize: 4,
       idleTimeout: 1000,

--- a/local/mock-services/services.json
+++ b/local/mock-services/services.json
@@ -249,6 +249,56 @@
                 }
             },
             "version": "v3"
+        },
+        {
+            "id": "test_admin1",
+            "result": {
+                "success": true,
+                "status": 200,
+                "metadata": null,
+                "content": {
+                    "maxRating": {
+                        "rating": 1114,
+                        "track": "DATA_SCIENCE",
+                        "subTrack": "SRM"
+                    },
+                    "createdBy": "40011578",
+                    "updatedBy": "40011578",
+                    "userId": 40135978,
+                    "firstName": "Adminname",
+                    "lastName": "Adminlastname",
+                    "quote": "It is a mistake to think you can solve any major problems just with potatoes.",
+                    "description": null,
+                    "otherLangName": null,
+                    "handle": "test_admin1",
+                    "handleLower": "test_admin1",
+                    "status": "ACTIVE",
+                    "email": "pshah1@test.com",
+                    "addresses": [
+                        {
+                            "streetAddr1": "100 Main Street",
+                            "streetAddr2": "",
+                            "city": "Chicago",
+                            "zip": "60601",
+                            "stateCode": "IL",
+                            "type": "HOME",
+                            "updatedAt": null,
+                            "createdAt": null,
+                            "createdBy": null,
+                            "updatedBy": null
+                        }
+                    ],
+                    "homeCountryCode": "USA",
+                    "competitionCountryCode": "USA",
+                    "photoURL": null,
+                    "tracks": [
+                        "DEVELOP"
+                    ],
+                    "updatedAt": "2015-12-02T14:00Z",
+                    "createdAt": "2014-04-10T10:55Z"
+                }
+            },
+            "version": "v3"
         }
     ]
 }


### PR DESCRIPTION
- Improved example config `sample.local.js`
   - added `identityServiceEndpoint: "http://dockerhost:3001/"` otherwise we cannot create a new project, as this endpoint is being used to mock `getSystemUserToken` request which is required to call a member service, see https://github.com/topcoder-platform/tc-project-service/blob/dev/local/mock-services/authMiddleware.js
    - edited `memberServiceEndpoint: 'http://dockerhost:3001/v3/members',` to match the URL which is mocked by local deployment, see https://github.com/topcoder-platform/tc-project-service/blob/dev/local/mock-services/server.js#L24
     - edited `masterUrl: 'postgres://coder:mysecretpassword@dockerhost:5432/projectsdb',` as by default configuration Postgres is run on port `5432`, see https://github.com/topcoder-platform/tc-project-service/blob/dev/local/docker-compose.yml#L10

- Added one more user to the mocked member service. This user's JWT is provided in the https://github.com/topcoder-platform/tc-project-service/blob/dev/README.md. Otherwise if we create a new project using this JWT, we will get error, as memeber service doesn't know the user encoded in the token.