### PR TITLE
Separated the raising of project and phase events from timeline/milestone changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ workflows:
             - test
           filters:
             branches:
-              only: ['dev', 'feature/timeline-milestone']
+              only: ['dev']
       - deployProd:
           requires:
             - test

--- a/src/constants.js
+++ b/src/constants.js
@@ -101,11 +101,14 @@ export const BUS_API_EVENT = {
 
   // When milestone is added/deleted to/from the phase,
   // When milestone is updated for duration/startDate/endDate/status
-  TIMELINE_MODIFIED: 'notifications.connect.project.phase.timelineModified',
+  TIMELINE_ADJUSTED: 'notifications.connect.project.phase.timeline.adjusted',
 
   // When specification of a product is modified
   PROJECT_PRODUCT_SPECIFICATION_MODIFIED: 'notifications.connect.project.productSpecificationModified',
 
+  MILESTONE_ADDED: 'notifications.connect.project.phase.milestone.added',
+  MILESTONE_REMOVED: 'notifications.connect.project.phase.milestone.removed',
+  MILESTONE_UPDATED: 'notifications.connect.project.phase.milestone.updated',
   // When milestone is marked as active
   MILESTONE_TRANSITION_ACTIVE: 'notifications.connect.project.phase.milestone.transition.active',
   // When milestone is marked as completed

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -10,8 +10,18 @@ import { projectPhaseAddedHandler, projectPhaseRemovedHandler,
   projectPhaseUpdatedHandler } from './projectPhases';
 import { phaseProductAddedHandler, phaseProductRemovedHandler,
   phaseProductUpdatedHandler } from './phaseProducts';
-import { timelineAddedHandler, timelineUpdatedHandler, timelineRemovedHandler } from './timelines';
-import { milestoneAddedHandler, milestoneUpdatedHandler, milestoneRemovedHandler } from './milestones';
+import {
+  timelineAddedHandler,
+  timelineUpdatedHandler,
+  timelineRemovedHandler,
+  timelineAdjustedKafkaHandler,
+} from './timelines';
+import {
+  milestoneAddedHandler,
+  milestoneUpdatedHandler,
+  milestoneRemovedHandler,
+  milestoneUpdatedKafkaHandler,
+} from './milestones';
 
 export const rabbitHandlers = {
   'project.initial': projectCreatedHandler,
@@ -56,4 +66,8 @@ export const kafkaHandlers = {
   [BUS_API_EVENT.TOPIC_UPDATED]: projectUpdatedKafkaHandler,
   [BUS_API_EVENT.POST_CREATED]: projectUpdatedKafkaHandler,
   [BUS_API_EVENT.POST_UPDATED]: projectUpdatedKafkaHandler,
+
+  // Events coming from timeline/milestones (considering it as a separate module/service in future)
+  [BUS_API_EVENT.MILESTONE_TRANSITION_COMPLETED]: milestoneUpdatedKafkaHandler,
+  [BUS_API_EVENT.TIMELINE_ADJUSTED]: timelineAdjustedKafkaHandler,
 };

--- a/src/events/milestones/index.js
+++ b/src/events/milestones/index.js
@@ -3,8 +3,12 @@
  */
 import config from 'config';
 import _ from 'lodash';
+import Joi from 'joi';
 import Promise from 'bluebird';
 import util from '../../util';
+// import { createEvent } from '../../services/busApi';
+import { EVENT, TIMELINE_REFERENCES, MILESTONE_STATUS, REGEX } from '../../constants';
+import models from '../../models';
 
 const ES_TIMELINE_INDEX = config.get('elasticsearchConfig.timelineIndexName');
 const ES_TIMELINE_TYPE = config.get('elasticsearchConfig.timelineDocType');
@@ -154,9 +158,105 @@ const milestoneRemovedHandler = Promise.coroutine(function* (logger, msg, channe
   }
 });
 
+/**
+ * Kafka event handlers
+ */
+
+const payloadSchema = Joi.object().keys({
+  projectId: Joi.number().integer().positive().required(),
+  projectName: Joi.string().optional(),
+  projectUrl: Joi.string().regex(REGEX.URL).optional(),
+  userId: Joi.number().integer().positive().required(),
+  initiatorUserId: Joi.number().integer().positive().required(),
+}).unknown(true).required();
+
+const findProjectPhaseProduct = function (logger, productId, raw = true) { // eslint-disable-line func-names
+  let product;
+  return models.PhaseProduct.findOne({
+    where: { id: productId },
+    raw,
+  }).then((_product) => {
+    logger.debug('_product', _product);
+    if (_product) {
+      product = _product;
+      const phaseId = product.phaseId;
+      const projectId = product.projectId;
+      return Promise.all([
+        models.ProjectPhase.findOne({
+          where: { id: phaseId, projectId },
+          raw,
+        }),
+        models.Project.findOne({
+          where: { id: projectId },
+          raw,
+        }),
+      ]);
+    }
+    return Promise.reject('Unable to find product');
+  }).then((projectAndPhase) => {
+    logger.debug('projectAndPhase', projectAndPhase);
+    if (projectAndPhase) {
+      const phase = projectAndPhase[0];
+      const project = projectAndPhase[1];
+      return Promise.resolve({ product, phase, project });
+    }
+    return Promise.reject('Unable to find phase/project');
+  });
+};
+
+/**
+ * Raises the project plan modified event
+ * @param   {Object}  app       Application object used to interact with RMQ service
+ * @param   {String}  topic     Kafka topic
+ * @param   {Object}  payload   Message payload
+ * @return  {Promise} Promise
+ */
+async function milestoneUpdatedKafkaHandler(app, topic, payload) {
+  app.logger.info(`Handling Kafka event for ${topic}`);
+  // Validate payload
+  const result = Joi.validate(payload, payloadSchema);
+  if (result.error) {
+    throw new Error(result.error);
+  }
+
+  const timeline = payload.timeline;
+  // process only if timeline is related to a product reference
+  if (timeline && timeline.reference === TIMELINE_REFERENCES.PRODUCT) {
+    const productId = timeline.referenceId;
+    const original = payload.originalMilestone;
+    const updated = payload.updatedMilestone;
+    app.logger.debug('Calling findProjectPhaseProduct');
+    const { project, phase } = await findProjectPhaseProduct(app.logger, productId, false);
+    app.logger.debug('Successfully fetched project, phase and product');
+    if (original.status !== updated.status) {
+      if (updated.status === MILESTONE_STATUS.COMPLETED) {
+        app.logger.debug('Found milestone status to be completed');
+        app.logger.debug(`Duration: ${timeline.duration}`);
+        if (!isNaN(timeline.duration) && !isNaN(timeline.progress)) {
+          app.logger.debug(`Current phase progress ${phase.progress} and duration ${phase.duration}`);
+          const updatedPhase = await phase.update({
+            progress: timeline.progress,
+            duration: timeline.duration,
+          }, ['progress', 'duration']);
+          app.logger.debug(`Updated phase progress ${timeline.progress} and duration ${timeline.duration}`);
+          app.logger.debug('Raising node event for PROJECT_PHASE_UPDATED');
+          app.emit(EVENT.ROUTING_KEY.PROJECT_PHASE_UPDATED, {
+            req: {
+              params: { projectId: project.id, phaseId: phase.id },
+              authUser: { userId: payload.userId },
+            },
+            original: phase,
+            updated: _.omit(updatedPhase.toJSON(), 'deletedAt', 'deletedBy'),
+          });
+        }
+      }
+    }
+  }
+}
 
 module.exports = {
   milestoneAddedHandler,
   milestoneRemovedHandler,
   milestoneUpdatedHandler,
+  milestoneUpdatedKafkaHandler,
 };

--- a/src/events/timelines/index.js
+++ b/src/events/timelines/index.js
@@ -2,13 +2,28 @@
  * Event handlers for timeline create, update and delete
  */
 import _ from 'lodash';
+import Joi from 'joi';
 import Promise from 'bluebird';
 import config from 'config';
 import util from '../../util';
+import { BUS_API_EVENT, TIMELINE_REFERENCES, REGEX } from '../../constants';
+import models from '../../models';
+import { createEvent } from '../../services/busApi';
 
 const ES_TIMELINE_INDEX = config.get('elasticsearchConfig.timelineIndexName');
 const ES_TIMELINE_TYPE = config.get('elasticsearchConfig.timelineDocType');
 const eClient = util.getElasticSearchClient();
+
+
+/**
+ * Builds the connect project url for the given project id.
+ *
+ * @param {string|number} projectId the project id
+ * @returns {string} the connect project url
+ */
+function connectProjectUrl(projectId) {
+  return `${config.get('connectProjectsUrl')}${projectId}`;
+}
 
 /**
  * Handler for timeline creation event
@@ -81,10 +96,89 @@ const timelineRemovedHandler = Promise.coroutine(function* (logger, msg, channel
     channel.nack(msg, false, !msg.fields.redelivered);
   }
 });
+/**
+ * Kafka event handlers
+ */
 
+const payloadSchema = Joi.object().keys({
+  projectId: Joi.number().integer().positive().required(),
+  projectName: Joi.string().optional(),
+  projectUrl: Joi.string().regex(REGEX.URL).optional(),
+  userId: Joi.number().integer().positive().required(),
+  initiatorUserId: Joi.number().integer().positive().required(),
+}).unknown(true).required();
+
+const findProjectPhaseProduct = function (logger, productId) { // eslint-disable-line func-names
+  let product;
+  return models.PhaseProduct.findOne({
+    where: { id: productId },
+    raw: true,
+  }).then((_product) => {
+    logger.debug('_product', _product);
+    if (_product) {
+      product = _product;
+      const phaseId = product.phaseId;
+      const projectId = product.projectId;
+      return Promise.all([
+        models.ProjectPhase.findOne({
+          where: { id: phaseId, projectId },
+          raw: true,
+        }),
+        models.Project.findOne({
+          where: { id: projectId },
+          raw: true,
+        }),
+      ]);
+    }
+    return Promise.reject('Unable to find product');
+  }).then((projectAndPhase) => {
+    logger.debug('projectAndPhase', projectAndPhase);
+    if (projectAndPhase) {
+      const phase = projectAndPhase[0];
+      const project = projectAndPhase[1];
+      return Promise.resolve({ product, phase, project });
+    }
+    return Promise.reject('Unable to find phase/project');
+  });
+};
+
+/**
+ * Raises the project plan modified event
+ * @param   {Object}  app       Application object used to interact with RMQ service
+ * @param   {String}  topic     Kafka topic
+ * @param   {Object}  payload   Message payload
+ * @return  {Promise} Promise
+ */
+async function timelineAdjustedKafkaHandler(app, topic, payload) {
+  app.logger.debug(`Handling Kafka event for ${topic}`);
+  // Validate payload
+  const result = Joi.validate(payload, payloadSchema);
+  if (result.error) {
+    throw new Error(result.error);
+  }
+
+  const timeline = payload.updatedTimeline;
+  // process only if timeline is related to a product reference
+  if (timeline && timeline.reference === TIMELINE_REFERENCES.PRODUCT) {
+    app.logger.debug('Found product timelin event ');
+    const productId = timeline.referenceId;
+    app.logger.debug('Calling findProjectPhaseProduct');
+    const { project } = await findProjectPhaseProduct(app.logger, productId);
+    app.logger.debug('Successfully fetched project, phase and product');
+    app.logger.debug('Raising BUS event for PROJECT_PLAN_UPDATED');
+    createEvent(BUS_API_EVENT.PROJECT_PLAN_UPDATED, {
+      projectId: project.id,
+      projectName: project.name,
+      projectUrl: connectProjectUrl(project.id),
+      userId: payload.userId,
+      initiatorUserId: payload.userId,
+    }, app.logger);
+  }
+}
 
 module.exports = {
   timelineAddedHandler,
   timelineUpdatedHandler,
   timelineRemovedHandler,
+  timelineAdjustedKafkaHandler,
 };

--- a/src/routes/milestones/create.spec.js
+++ b/src/routes/milestones/create.spec.js
@@ -629,7 +629,7 @@ describe('CREATE milestone', () => {
         sandbox.restore();
       });
 
-      it('should send message BUS_API_EVENT.PROJECT_PLAN_UPDATED when milestone created', (done) => {
+      it('should send message BUS_API_EVENT.TIMELINE_ADJUSTED when milestone created', (done) => {
         request(server)
           .post('/v4/timelines/1/milestones')
           .set({
@@ -644,7 +644,7 @@ describe('CREATE milestone', () => {
             } else {
               testUtil.wait(() => {
                 createEventSpy.calledOnce.should.be.true;
-                createEventSpy.calledWith(BUS_API_EVENT.PROJECT_PLAN_UPDATED, sinon.match({
+                createEventSpy.calledWith(BUS_API_EVENT.MILESTONE_ADDED, sinon.match({
                   projectId: 1,
                   projectName: 'test1',
                   projectUrl: 'https://local.topcoder-dev.com/projects/1',

--- a/src/routes/milestones/delete.spec.js
+++ b/src/routes/milestones/delete.spec.js
@@ -373,8 +373,8 @@ describe('DELETE milestone', () => {
       });
 
       // not testing fields separately as startDate is required parameter,
-      // thus PROJECT_PLAN_UPDATED will be always sent
-      it('should send message BUS_API_EVENT.PROJECT_PLAN_UPDATED when milestone removed', (done) => {
+      // thus TIMELINE_ADJUSTED will be always sent
+      it('should send message BUS_API_EVENT.TIMELINE_ADJUSTED when milestone removed', (done) => {
         request(server)
           .delete('/v4/timelines/1/milestones/1')
           .set({
@@ -387,7 +387,7 @@ describe('DELETE milestone', () => {
             } else {
               testUtil.wait(() => {
                 createEventSpy.calledOnce.should.be.true;
-                createEventSpy.calledWith(BUS_API_EVENT.PROJECT_PLAN_UPDATED, sinon.match({
+                createEventSpy.calledWith(BUS_API_EVENT.MILESTONE_REMOVED, sinon.match({
                   projectId: 1,
                   projectName: 'test1',
                   projectUrl: 'https://local.topcoder-dev.com/projects/1',

--- a/src/routes/milestones/update.spec.js
+++ b/src/routes/milestones/update.spec.js
@@ -1102,7 +1102,7 @@ describe('UPDATE Milestone', () => {
         sandbox.restore();
       });
 
-      it('should send message BUS_API_EVENT.PROJECT_PLAN_UPDATED when milestone duration updated', (done) => {
+      it('should send message BUS_API_EVENT.TIMELINE_ADJUSTED when milestone duration updated', (done) => {
         request(server)
           .patch('/v4/timelines/1/milestones/1')
           .set({
@@ -1119,22 +1119,25 @@ describe('UPDATE Milestone', () => {
               done(err);
             } else {
               testUtil.wait(() => {
-                createEventSpy.calledTwice.should.be.true;
-                createEventSpy.firstCall.calledWith(BUS_API_EVENT.PROJECT_PLAN_UPDATED, sinon.match({
+                // 5 milestones in total, so it would trigger 5 events
+                // 4 MILESTONE_UPDATED events are for 4 non deleted milestones
+                // 1 TIMELINE_ADJUSTED event, because timeline's end date updated
+                createEventSpy.callCount.should.be.eql(5);
+                createEventSpy.firstCall.calledWith(BUS_API_EVENT.MILESTONE_UPDATED, sinon.match({
                   projectId: 1,
                   projectName: 'test1',
                   projectUrl: 'https://local.topcoder-dev.com/projects/1',
                   userId: 40051332,
                   initiatorUserId: 40051332,
                 })).should.be.true;
-                createEventSpy.secondCall.calledWith(BUS_API_EVENT.TIMELINE_MODIFIED);
+                createEventSpy.lastCall.calledWith(BUS_API_EVENT.TIMELINE_ADJUSTED);
                 done();
               });
             }
           });
       });
 
-      it('should send message BUS_API_EVENT.PROJECT_PLAN_UPDATED when milestone status updated', (done) => {
+      it('should send message BUS_API_EVENT.MILESTONE_UPDATED when milestone status updated', (done) => {
         request(server)
           .patch('/v4/timelines/1/milestones/1')
           .set({
@@ -1152,7 +1155,7 @@ describe('UPDATE Milestone', () => {
             } else {
               testUtil.wait(() => {
                 createEventSpy.calledOnce.should.be.true;
-                createEventSpy.firstCall.calledWith(BUS_API_EVENT.PROJECT_PLAN_UPDATED, sinon.match({
+                createEventSpy.firstCall.calledWith(BUS_API_EVENT.MILESTONE_UPDATED, sinon.match({
                   projectId: 1,
                   projectName: 'test1',
                   projectUrl: 'https://local.topcoder-dev.com/projects/1',
@@ -1165,7 +1168,7 @@ describe('UPDATE Milestone', () => {
           });
       });
 
-      it('should send message BUS_API_EVENT.PROJECT_PLAN_UPDATED when milestone order updated', (done) => {
+      it('should ONLY send message BUS_API_EVENT.MILESTONE_UPDATED when milestone order updated', (done) => {
         request(server)
           .patch('/v4/timelines/1/milestones/1')
           .set({
@@ -1183,7 +1186,7 @@ describe('UPDATE Milestone', () => {
             } else {
               testUtil.wait(() => {
                 createEventSpy.calledOnce.should.be.true;
-                createEventSpy.firstCall.calledWith(BUS_API_EVENT.PROJECT_PLAN_UPDATED, sinon.match({
+                createEventSpy.firstCall.calledWith(BUS_API_EVENT.MILESTONE_UPDATED, sinon.match({
                   projectId: 1,
                   projectName: 'test1',
                   projectUrl: 'https://local.topcoder-dev.com/projects/1',
@@ -1196,7 +1199,7 @@ describe('UPDATE Milestone', () => {
           });
       });
 
-      it('should not send message BUS_API_EVENT.PROJECT_PLAN_UPDATED when milestone plannedText updated', (done) => {
+      it('should ONLY send message BUS_API_EVENT.MILESTONE_UPDATED when milestone plannedText updated', (done) => {
         request(server)
           .patch('/v4/timelines/1/milestones/1')
           .set({
@@ -1213,7 +1216,14 @@ describe('UPDATE Milestone', () => {
               done(err);
             } else {
               testUtil.wait(() => {
-                createEventSpy.notCalled.should.be.true;
+                createEventSpy.calledOnce.should.be.true;
+                createEventSpy.firstCall.calledWith(BUS_API_EVENT.MILESTONE_UPDATED, sinon.match({
+                  projectId: 1,
+                  projectName: 'test1',
+                  projectUrl: 'https://local.topcoder-dev.com/projects/1',
+                  userId: 40051332,
+                  initiatorUserId: 40051332,
+                })).should.be.true;
                 done();
               });
             }

--- a/src/routes/timelines/update.spec.js
+++ b/src/routes/timelines/update.spec.js
@@ -648,8 +648,8 @@ describe('UPDATE timeline', () => {
       });
 
       // not testing fields separately as startDate is required parameter,
-      // thus PROJECT_PLAN_UPDATED will be always sent
-      it('should send message BUS_API_EVENT.PROJECT_PLAN_UPDATED when timeline updated', (done) => {
+      // thus TIMELINE_ADJUSTED will be always sent
+      it('should send message BUS_API_EVENT.TIMELINE_ADJUSTED when timeline updated', (done) => {
         request(server)
           .patch('/v4/timelines/1')
           .set({
@@ -663,7 +663,7 @@ describe('UPDATE timeline', () => {
             } else {
               testUtil.wait(() => {
                 createEventSpy.calledOnce.should.be.true;
-                createEventSpy.calledWith(BUS_API_EVENT.PROJECT_PLAN_UPDATED, sinon.match({
+                createEventSpy.calledWith(BUS_API_EVENT.TIMELINE_ADJUSTED, sinon.match({
                   projectId: 1,
                   projectName: 'test1',
                   projectUrl: 'https://local.topcoder-dev.com/projects/1',


### PR DESCRIPTION
Now we consume the timeline/milestone events in project service itself and then raise the appropriate events. Another important change is that based on timeline/milestone changes, it updates the phase’s data e.g. it now updates the phase’s progress and duration when a milestone is completed or milestone duration is changed.