### PR TITLE
Hotfix/gzip compression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ workflows:
             - test
           filters:
             branches:
-              only: ['dev', 'hotfix/gzip_compression']
+              only: ['dev']
       - deployProd:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ workflows:
             - test
           filters:
             branches:
-              only: ['dev']
+              only: ['dev', 'hotfix/gzip_compression']
       - deployProd:
           requires:
             - test

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "bluebird": "^3.4.1",
     "body-parser": "^1.15.0",
     "co": "^4.6.0",
+    "compression": "^1.7.3",
     "config": "^1.20.1",
     "continuation-local-storage": "^3.1.7",
     "cors": "^2.8.4",

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -48,7 +48,7 @@ router.route('/v4/projects/metadata/productCategories/:key')
   .get(require('./productCategories/get'));
 
 
-router.use(`/v4/projects/metadata`, compression());
+router.use('/v4/projects/metadata', compression());
 router.route('/v4/projects/metadata')
   .get(require('./metadata/list'));
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import config from 'config';
 import validate from 'express-validation';
 import { Router } from 'express';
+import compression from 'compression';
 
 const router = Router();
 
@@ -46,6 +47,8 @@ router.route('/v4/projects/metadata/productCategories')
 router.route('/v4/projects/metadata/productCategories/:key')
   .get(require('./productCategories/get'));
 
+
+router.use(`/v4/projects/metadata`, compression());
 router.route('/v4/projects/metadata')
   .get(require('./metadata/list'));
 


### PR DESCRIPTION
Using gzip compression for metadata list endpoint to reduce the time in loading the metadata. Tested in dev, it seems to work fine. Still need to watch the production after this patch.