### PR TITLE
Limit draft phase update events to topcoder project members

### DIFF
--- a/src/events/busApi.js
+++ b/src/events/busApi.js
@@ -4,6 +4,7 @@ import { EVENT, BUS_API_EVENT, PROJECT_STATUS, PROJECT_PHASE_STATUS, PROJECT_MEM
   from '../constants';
 import { createEvent } from '../services/busApi';
 import models from '../models';
+import getTopcoderProjectMembers from '../util';
 
 /**
  * Map of project status and event name sent to bus api
@@ -363,6 +364,8 @@ module.exports = (app, logger) => {
           projectUrl: connectProjectUrl(projectId),
           userId: req.authUser.userId,
           initiatorUserId: req.authUser.userId,
+          allowedUsers: created.status === PROJECT_PHASE_STATUS.DRAFT ?
+            getTopcoderProjectMembers(project.members) : null,
         }, logger);
         return sendPlanReadyEventIfNeeded(req, project, created);
       }).catch(err => null);    // eslint-disable-line no-unused-vars
@@ -387,6 +390,8 @@ module.exports = (app, logger) => {
           projectUrl: connectProjectUrl(projectId),
           userId: req.authUser.userId,
           initiatorUserId: req.authUser.userId,
+          allowedUsers: deleted.status === PROJECT_PHASE_STATUS.DRAFT ?
+            getTopcoderProjectMembers(project.members) : null,
         }, logger);
       }).catch(err => null);    // eslint-disable-line no-unused-vars
   });
@@ -438,6 +443,8 @@ module.exports = (app, logger) => {
               projectName: project.name,
               userId: req.authUser.userId,
               initiatorUserId: req.authUser.userId,
+              allowedUsers: updated.status === PROJECT_PHASE_STATUS.DRAFT ?
+                getTopcoderProjectMembers(project.members) : null,
             }, logger));
             events.forEach((event) => { eventsMap[event] = true; });
           }
@@ -483,6 +490,8 @@ module.exports = (app, logger) => {
             projectUrl: connectProjectUrl(projectId),
             userId: req.authUser.userId,
             initiatorUserId: req.authUser.userId,
+            allowedUsers: updated.status === PROJECT_PHASE_STATUS.DRAFT ?
+              getTopcoderProjectMembers(project.members) : null,
           }, logger);
         }
       }).catch(err => null);    // eslint-disable-line no-unused-vars

--- a/src/util.js
+++ b/src/util.js
@@ -18,7 +18,7 @@ import elasticsearch from 'elasticsearch';
 import Promise from 'bluebird';
 // import AWS from 'aws-sdk';
 
-import { ADMIN_ROLES, TOKEN_SCOPES, EVENT } from './constants';
+import { ADMIN_ROLES, TOKEN_SCOPES, EVENT, PROJECT_MEMBER_ROLE } from './constants';
 
 const exec = require('child_process').exec;
 const models = require('./models').default;
@@ -468,6 +468,13 @@ _.assignIn(util, {
       });
     });
   },
+
+  /**
+   * Filter only members of topcoder team
+   * @param {Array}  members        project members
+   * @return {Array} tpcoder project members
+   */
+  getTopcoderProjectMembers: members => _(members).filter(m => m.role !== PROJECT_MEMBER_ROLE.CUSTOMER),
 });
 
 export default util;


### PR DESCRIPTION
@vikasrohit this one fixes https://github.com/topcoder-platform/tc-notifications/issues/85
we'll limit the notifications only to topcoder team if phase is not visible to customer (draft)