### PR TITLE
Add new filters for projects list (without ID)

### DIFF
--- a/migrations/elasticsearch_sync.js
+++ b/migrations/elasticsearch_sync.js
@@ -209,8 +209,7 @@ function getRequestBody(indexName) {
         },
       },
       id: {
-        type: 'string',
-        index: 'not_analyzed',
+        type: 'long',
       },
       members: {
         type: 'nested',

--- a/migrations/elasticsearch_sync.js
+++ b/migrations/elasticsearch_sync.js
@@ -209,7 +209,8 @@ function getRequestBody(indexName) {
         },
       },
       id: {
-        type: 'long',
+        type: 'string',
+        index: 'not_analyzed',
       },
       members: {
         type: 'nested',

--- a/postman.json
+++ b/postman.json
@@ -1486,6 +1486,120 @@
 					"response": []
 				},
 				{
+					"name": "List projects with filters - name, code, customer, manager",
+					"request": {
+						"url": {
+							"raw": "{{api-url}}/v4/projects?filter=id%3D1*%26name%3Dtes*%26code=test*%26customer%3DDiya*%26manager=first*",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"v4",
+								"projects"
+							],
+							"query": [
+								{
+									"key": "filter",
+									"value": "id%3D1*%26name%3Dtes*%26code=test*%26customer%3DDiya*%26manager=first*",
+									"equals": true,
+									"description": ""
+								}
+							],
+							"variable": []
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt-token}}",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"description": "List all the project with filters applied. The filter string should be url encoded. Default limit and offset is applicable"
+					},
+					"response": []
+				},
+				{
+					"name": "List projects with filters - id",
+					"request": {
+						"url": {
+							"raw": "{{api-url}}/v4/projects?filter=id%3D2",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"v4",
+								"projects"
+							],
+							"query": [
+								{
+									"key": "filter",
+									"value": "id%3D2",
+									"equals": true,
+									"description": ""
+								}
+							],
+							"variable": []
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt-token}}",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"description": "List all the project with filters applied. The filter string should be url encoded. Default limit and offset is applicable"
+					},
+					"response": []
+				},
+				{
+					"name": "List projects with filters - code",
+					"request": {
+						"url": {
+							"raw": "{{api-url}}/v4/projects?filter=code%3Dtest*",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"v4",
+								"projects"
+							],
+							"query": [
+								{
+									"key": "filter",
+									"value": "code%3Dtest*",
+									"equals": true,
+									"description": ""
+								}
+							],
+							"variable": []
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt-token}}",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"description": "List all the project with filters applied. The filter string should be url encoded. Default limit and offset is applicable"
+					},
+					"response": []
+				},
+				{
 					"name": "List projects with sort applied",
 					"request": {
 						"method": "GET",

--- a/postman.json
+++ b/postman.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "97085cd7-b298-4f1c-9629-24af14ff5f13",
+		"_postman_id": "4fc2b7cf-404a-4fd7-b6d2-4828a3994859",
 		"name": "tc-project-service",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1452,7 +1452,7 @@
 					"response": []
 				},
 				{
-					"name": "List projects with filters applied",
+					"name": "List projects with filters - type (exact)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -1466,7 +1466,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{api-url}}/v4/projects?filter=type%3Dgeneric",
+							"raw": "{{api-url}}/v4/projects?filter=type%3Dapp",
 							"host": [
 								"{{api-url}}"
 							],
@@ -1477,7 +1477,41 @@
 							"query": [
 								{
 									"key": "filter",
-									"value": "type%3Dgeneric"
+									"value": "type%3Dapp"
+								}
+							]
+						},
+						"description": "List all the project with filters applied. The filter string should be url encoded. Default limit and offset is applicable"
+					},
+					"response": []
+				},
+				{
+					"name": "List projects with filters - id (exact)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt-token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api-url}}/v4/projects?filter=id%3D1",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"v4",
+								"projects"
+							],
+							"query": [
+								{
+									"key": "filter",
+									"value": "id%3D1"
 								}
 							]
 						},
@@ -1488,6 +1522,17 @@
 				{
 					"name": "List projects with filters - name, code, customer, manager",
 					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt-token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{api-url}}/v4/projects?filter=id%3D1*%26name%3Dtes*%26code=test*%26customer%3DDiya*%26manager=first*",
 							"host": [
@@ -1500,62 +1545,9 @@
 							"query": [
 								{
 									"key": "filter",
-									"value": "id%3D1*%26name%3Dtes*%26code=test*%26customer%3DDiya*%26manager=first*",
-									"equals": true,
-									"description": ""
+									"value": "id%3D1*%26name%3Dtes*%26code=test*%26customer%3DDiya*%26manager=first*"
 								}
-							],
-							"variable": []
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{jwt-token}}",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"description": "List all the project with filters applied. The filter string should be url encoded. Default limit and offset is applicable"
-					},
-					"response": []
-				},
-				{
-					"name": "List projects with filters - id",
-					"request": {
-						"url": {
-							"raw": "{{api-url}}/v4/projects?filter=id%3D2",
-							"host": [
-								"{{api-url}}"
-							],
-							"path": [
-								"v4",
-								"projects"
-							],
-							"query": [
-								{
-									"key": "filter",
-									"value": "id%3D2",
-									"equals": true,
-									"description": ""
-								}
-							],
-							"variable": []
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{jwt-token}}",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
+							]
 						},
 						"description": "List all the project with filters applied. The filter string should be url encoded. Default limit and offset is applicable"
 					},
@@ -1564,6 +1556,17 @@
 				{
 					"name": "List projects with filters - code",
 					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt-token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{api-url}}/v4/projects?filter=code%3Dtest*",
 							"host": [
@@ -1576,24 +1579,9 @@
 							"query": [
 								{
 									"key": "filter",
-									"value": "code%3Dtest*",
-									"equals": true,
-									"description": ""
+									"value": "code%3Dtest*"
 								}
-							],
-							"variable": []
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{jwt-token}}",
-								"description": ""
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
+							]
 						},
 						"description": "List all the project with filters applied. The filter string should be url encoded. Default limit and offset is applicable"
 					},

--- a/src/routes/projects/list.js
+++ b/src/routes/projects/list.js
@@ -241,8 +241,6 @@ const parseElasticSearchCriteria = (criteria, fields, order) => {
         values: criteria.filters.id.$in,
       },
     });
-  } else if (_.has(criteria, 'filters.id') && criteria.filters.id.indexOf('*') > -1) {
-    mustQuery = _.concat(mustQuery, buildEsQueryWithFilter('id', criteria.filters.id, MATCH_TYPE_WILDCARD, ['id']));
   } else if (_.has(criteria, 'filters.id')) {
     boolQuery.push({
       term: {
@@ -287,6 +285,21 @@ const parseElasticSearchCriteria = (criteria, fields, order) => {
     });
   }
 
+  if (_.has(criteria, 'filters.type.$in')) {
+    // type is an array
+    boolQuery.push({
+      terms: {
+        type: criteria.filters.type.$in,
+      },
+    });
+  } else if (_.has(criteria, 'filters.type')) {
+    // type is simple string
+    boolQuery.push({
+      term: {
+        type: criteria.filters.type,
+      },
+    });
+  }
   if (_.has(criteria, 'filters.keyword')) {
     // keyword is a full text search
     // escape special fields from keyword search
@@ -400,7 +413,7 @@ module.exports = [
       'type', 'type asc', 'type desc',
     ];
     if (!util.isValidFilter(filters,
-      ['id', 'status', 'memberOnly', 'keyword', 'name', 'code', 'customer', 'manager']) ||
+      ['id', 'status', 'memberOnly', 'keyword', 'type', 'name', 'code', 'customer', 'manager']) ||
       (sort && _.indexOf(sortableProps, sort) < 0)) {
       return util.handleError('Invalid filters or sort', null, req, next);
     }

--- a/src/routes/projects/list.spec.js
+++ b/src/routes/projects/list.spec.js
@@ -513,9 +513,9 @@ describe('LIST Project', () => {
         });
     });
 
-    it('should return project that match when filtering by id', (done) => {
+    it('should return project that match when filtering by id (exact)', (done) => {
       request(server)
-        .get('/v4/projects/?filter=id%3D1*')
+        .get('/v4/projects/?filter=id%3D1')
         .set({
           Authorization: `Bearer ${testUtil.jwts.admin}`,
         })

--- a/src/routes/projects/list.spec.js
+++ b/src/routes/projects/list.spec.js
@@ -37,6 +37,8 @@ const data = [
         userId: 40051331,
         projectId: 1,
         role: 'customer',
+        firstName: 'Firstname',
+        lastName: 'Lastname',
         handle: 'test_tourist_handle',
         isPrimary: true,
         createdBy: 1,
@@ -101,6 +103,19 @@ const data = [
     updatedBy: 1,
     lastActivityAt: 3,
     lastActivityUserId: '1',
+    members: [{
+      id: 5,
+      userId: 40051334,
+      projectId: 2,
+      role: 'manager',
+      firstName: 'first',
+      lastName: 'last',
+      handle: 'manager_handle',
+      isPrimary: true,
+      createdBy: 1,
+      updatedBy: 1,
+    },
+    ],
   },
 ];
 
@@ -193,7 +208,18 @@ describe('LIST Project', () => {
           lastActivityUserId: '1',
         }).then((p) => {
           project3 = p;
-          return Promise.resolve();
+          // create members
+          return models.ProjectMember.create({
+            userId: 40051334,
+            projectId: project3.id,
+            role: 'manager',
+            firstName: 'first',
+            lastName: 'last',
+            handle: 'manager_handle',
+            isPrimary: true,
+            createdBy: 1,
+            updatedBy: 1,
+          });
         });
 
         return Promise.all([p1, p2, p3]).then(() => {
@@ -482,6 +508,160 @@ describe('LIST Project', () => {
             should.exist(resJson);
             resJson.should.have.lengthOf(1);
             resJson[0].name.should.equal('test1');
+            done();
+          }
+        });
+    });
+
+    it('should return project that match when filtering by id', (done) => {
+      request(server)
+        .get('/v4/projects/?filter=id%3D1*')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.admin}`,
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+          } else {
+            const resJson = res.body.result.content;
+            should.exist(resJson);
+            resJson.should.have.lengthOf(1);
+            resJson[0].id.should.equal(1);
+            resJson[0].name.should.equal('test1');
+            done();
+          }
+        });
+    });
+
+    it('should return project that match when filtering by name', (done) => {
+      request(server)
+        .get('/v4/projects/?filter=name%3Dtest1')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.admin}`,
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+          } else {
+            const resJson = res.body.result.content;
+            should.exist(resJson);
+            resJson.should.have.lengthOf(1);
+            resJson[0].name.should.equal('test1');
+            done();
+          }
+        });
+    });
+
+    it('should return project that match when filtering by name\'s substring', (done) => {
+      request(server)
+        .get('/v4/projects/?filter=name%3D*st1')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.admin}`,
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+          } else {
+            const resJson = res.body.result.content;
+            should.exist(resJson);
+            resJson.should.have.lengthOf(1);
+            resJson[0].name.should.equal('test1');
+            done();
+          }
+        });
+    });
+
+    it('should return all projects that match when filtering by details code', (done) => {
+      request(server)
+        .get('/v4/projects/?filter=code%3Dcode1')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.admin}`,
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+          } else {
+            const resJson = res.body.result.content;
+            should.exist(resJson);
+            resJson.should.have.lengthOf(1);
+            resJson[0].name.should.equal('test1');
+            resJson[0].details.utm.code.should.equal('code1');
+            done();
+          }
+        });
+    });
+
+    it('should return all projects that match when filtering by details code\'s substring', (done) => {
+      request(server)
+        .get('/v4/projects/?filter=code%3D*de1')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.admin}`,
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+          } else {
+            const resJson = res.body.result.content;
+            should.exist(resJson);
+            resJson.should.have.lengthOf(1);
+            resJson[0].name.should.equal('test1');
+            resJson[0].details.utm.code.should.equal('code1');
+            done();
+          }
+        });
+    });
+
+    it('should return all projects that match when filtering by customer', (done) => {
+      request(server)
+        .get('/v4/projects/?filter=customer%3Dfirst*')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.admin}`,
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+          } else {
+            const resJson = res.body.result.content;
+            should.exist(resJson);
+            resJson.should.have.lengthOf(1);
+            resJson[0].name.should.equal('test1');
+            resJson[0].members.should.have.deep.property('[0].role', 'customer');
+            resJson[0].members[0].userId.should.equal(40051331);
+            done();
+          }
+        });
+    });
+
+    it('should return all projects that match when filtering by manager', (done) => {
+      request(server)
+        .get('/v4/projects/?filter=manager%3D*ast')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.admin}`,
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+          } else {
+            const resJson = res.body.result.content;
+            should.exist(resJson);
+            resJson.should.have.lengthOf(1);
+            resJson[0].name.should.equal('test3');
+            resJson[0].members.should.have.deep.property('[0].role', 'manager');
+            resJson[0].members[0].userId.should.equal(40051334);
             done();
           }
         });

--- a/src/util.js
+++ b/src/util.js
@@ -180,7 +180,7 @@ _.assignIn(util, {
       }
       return val;
     });
-    if (queryFilter.id) {
+    if (queryFilter.id && queryFilter.id.$in) {
       queryFilter.id.$in = _.map(queryFilter.id.$in, _.parseInt);
     }
     return queryFilter;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -55,6 +55,10 @@ paths:
              - type
              - memberOnly
              - keyword
+             - name
+             - code
+             - customer
+             - manager
         - name: sort
           required: false
           description: |


### PR DESCRIPTION
winning submission for challenge 30083089 - Topcoder Connect - Filter project table by columns, fix for issue #245

- additionally was removed support for filtering by ID substring, so we don't need to reindex projects and change ID field type from long to string in ES index.
- also I've put back the support to filter by type, as it was removed in the challenge together with filtering by type in connect, but I think we may can keep it in project service