### PR TITLE
Improve process of running tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,21 +98,12 @@ To be able to run [Connect App](https://github.com/appirio-tech/connect-app) wit
 3. Restart both Connect App and Project Service if they were running.
 
 ### Test
+```bash
+npm run test
+```
+Tests are being executed with the `NODE_ENV` environment variable has a value `test` and `config/test.js` configuration is loaded.
 
 Each of the individual modules/services are unit tested.
-
-To run unit tests run `npm run test` from root of project.
-
-While tests are being executed the `NODE_ENV` environment variable has a value `test` and `config/test.js` configuration is loaded. The default test configuration refers to `projectsdb_test` postgres database. So make sure that this database exists before running the tests. Since we are using docker-compose for local deployment change `local/docker-compose.yaml` postgres service with updated database name and re-create the containers.
-
-```
-// stop already executing containers if any
-docker-compose stop -t 1
-// clear the containers
-docker-compose rm -f
-// re-run the services with build flag
-docker-compose up --build
-```
 
 #### JWT Authentication
 Authentication is handled via Authorization (Bearer) token header field. Token is a JWT token. Here is a sample token that is valid for a very long time for a user with administrator role.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Microservice to manage CRUD operations for all things Projects.
   docker-compose up
   ```
   This will run several services locally:
-  - `postgres`
+  - `postgres` - two instances: for app and for unit tests
   - `elasticsearch`
   - `rabbitmq`
   - `mock-services` - mocks some Topcoder API

--- a/config/test.json
+++ b/config/test.json
@@ -14,7 +14,7 @@
     "rabbitmqUrl": "amqp://localhost:5672",
     "connectProjectsUrl": "https://local.topcoder-dev.com/projects/",
     "dbConfig": {
-        "masterUrl": "postgres://coder:mysecretpassword@localhost:5432/projectsdb_test",
+        "masterUrl": "postgres://coder:mysecretpassword@localhost:5433/projectsdb_test",
         "maxPoolSize": 50,
         "minPoolSize": 4,
         "idleTimeout": 1000

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -12,6 +12,14 @@ services:
       - POSTGRES_PASSWORD=mysecretpassword
       - POSTGRES_USER=coder
       - POSTGRES_DB=projectsdb
+  db_test:
+    image: "postgres:9.5"
+    ports:
+      - "5433:5432"
+    environment:
+      - POSTGRES_PASSWORD=mysecretpassword
+      - POSTGRES_USER=coder
+      - POSTGRES_DB=projectsdb_test
   esearch:
     image: "elasticsearch:2.3"
     ports:


### PR DESCRIPTION
Tests are now running using a separate instance of PostgreSQL in docker-compose for tests, so we don't have to rebuild docker containers every time we want to switch from the app running to tests running.

fixes issue https://github.com/topcoder-platform/tc-project-service/issues/261