### PR TITLE
Product templates use sections

### DIFF
--- a/migrations/20190620_migrate_product_templates.sql
+++ b/migrations/20190620_migrate_product_templates.sql
@@ -1,0 +1,11 @@
+--
+-- UPDATE EXISTING TABLES:
+--   template:
+--     remove `sections` if exists and change `questions` to `sections`
+
+--
+-- product_templates
+
+UPDATE product_templates
+SET template = (template::jsonb #- '{questions}' #- '{sections}') || jsonb_build_object('sections', template::jsonb ->'questions')
+WHERE template::jsonb ? 'questions';

--- a/src/routes/metadata/list.spec.js
+++ b/src/routes/metadata/list.spec.js
@@ -111,7 +111,7 @@ const forms = [
   {
     key: 'productKey 1',
     config: {
-      questions: [{
+      sections: [{
         id: 'appDefinition',
         title: 'Sample Project',
         required: true,

--- a/src/routes/productTemplates/upgrade.spec.js
+++ b/src/routes/productTemplates/upgrade.spec.js
@@ -85,7 +85,7 @@ describe('UPGRADE product template', () => {
     ]))
     .then(() => {
       const config = {
-        questions: [{
+        sections: [{
           id: 'appDefinition',
           title: 'Sample Project',
           required: true,

--- a/src/routes/projectUpgrade/create.js
+++ b/src/routes/projectUpgrade/create.js
@@ -44,9 +44,9 @@ async function findCompletedProjectEndDate(projectId, transaction) {
  */
 function applyTemplate(template, source, destination) {
   if (!template || typeof template !== 'object') { return; }
-  if (!template.questions || !template.questions.length) { return; }
+  if (!template.sections || !template.sections.length) { return; }
   // questions field is actually array of sections
-  const templateQuestions = template.questions;
+  const templateQuestions = template.sections;
   // loop through for every section
   templateQuestions.forEach((section) => {
     // find subsections

--- a/src/routes/projectUpgrade/create.spec.js
+++ b/src/routes/projectUpgrade/create.spec.js
@@ -107,7 +107,7 @@ describe('Project upgrade', () => {
           alias2: [1, 2, 3],
         },
         template: {
-          questions: [
+          sections: [
             {
               subSections: [
                 { fieldName: 'details.name' },


### PR DESCRIPTION
Migration script to update all product templates to use `sections` instead of `questions`.

Issue https://github.com/appirio-tech/connect-app/issues/3107

winning submission from challenge 30093923 - Topcoder Connect - Product template update