### PR TITLE
Feature/topics for works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
         - POSTGRES_USER: circle_test
         - POSTGRES_DB: circle_test
       - image: elasticsearch:2.3
+      - image: rabbitmq:3-management
     environment:
       DB_MASTER_URL: postgres://circle_test:@127.0.0.1:5432/circle_test
       AUTH_SECRET: secret

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
     "mocha": true
   },
   "rules": {
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js", "**/*.spec.js", "**/serviceMocks.js"]}],
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js", "**/*.spec.js", "src/tests/*.js"]}],
     "max-len": ["error", { "ignoreComments": true, "code": 120 }],
     "valid-jsdoc": ["error", {
       "requireReturn": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3308,6 +3308,11 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -5598,18 +5603,26 @@
       }
     },
     "libpq": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/libpq/-/libpq-1.8.8.tgz",
-      "integrity": "sha512-0TVzqkbAZZiM8JJy5sagRyXOkvU9zTBlgGX6YdzuWECobc5F81Tp6uuS+djMZrnB5YN4O/ff52hsvXYBRW2gdQ==",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/libpq/-/libpq-1.8.9.tgz",
+      "integrity": "sha512-herU0STiW3+/XBoYRycKKf49O9hBKK0JbdC2QmvdC5pyCSu8prb9idpn5bUSbxj8XwcEsWPWWWwTDZE9ZTwJ7g==",
       "requires": {
-        "bindings": "1.2.1",
-        "nan": "^2.10.0"
+        "bindings": "1.5.0",
+        "nan": "^2.14.0"
       },
       "dependencies": {
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
         "nan": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-          "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         }
       }
     },

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -44,7 +44,6 @@ export const rabbitHandlers = {
   [EVENT.ROUTING_KEY.PROJECT_PHASE_PRODUCT_ADDED]: phaseProductAddedHandler,
   [EVENT.ROUTING_KEY.PROJECT_PHASE_PRODUCT_REMOVED]: phaseProductRemovedHandler,
   [EVENT.ROUTING_KEY.PROJECT_PHASE_PRODUCT_UPDATED]: phaseProductUpdatedHandler,
-
   // Timeline and milestone
   'timeline.initial': timelineAddedHandler,
   [EVENT.ROUTING_KEY.TIMELINE_ADDED]: timelineAddedHandler,

--- a/src/routes/phases/create.js
+++ b/src/routes/phases/create.js
@@ -5,7 +5,7 @@ import Sequelize from 'sequelize';
 
 import models from '../../models';
 import util from '../../util';
-import { EVENT } from '../../constants';
+import { EVENT, TIMELINE_REFERENCES } from '../../constants';
 
 const permissions = require('tc-core-library-js').middleware.permissions;
 
@@ -127,7 +127,7 @@ module.exports = [
         // Send events to buses
         req.log.debug('Sending event to RabbitMQ bus for project phase %d', newProjectPhase.id);
         req.app.services.pubsub.publish(EVENT.ROUTING_KEY.PROJECT_PHASE_ADDED,
-          newProjectPhase,
+          { added: newProjectPhase, route: TIMELINE_REFERENCES.PHASE },
           { correlationId: req.id },
         );
         req.log.debug('Sending event to Kafka bus for project phase %d', newProjectPhase.id);

--- a/src/routes/phases/create.spec.js
+++ b/src/routes/phases/create.spec.js
@@ -2,14 +2,20 @@
 import _ from 'lodash';
 import chai from 'chai';
 import sinon from 'sinon';
+import config from 'config';
 import request from 'supertest';
 import server from '../../app';
 import models from '../../models';
 import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
+import messageService from '../../services/messageService';
+import RabbitMQService from '../../services/rabbitmq';
 import {
   BUS_API_EVENT,
 } from '../../constants';
+
+const ES_PROJECT_INDEX = config.get('elasticsearchConfig.indexName');
+const ES_PROJECT_TYPE = config.get('elasticsearchConfig.docType');
 
 const should = chai.should();
 
@@ -57,22 +63,23 @@ describe('Project Phases', () => {
     lastName: 'lName',
     email: 'some@abc.com',
   };
+  const project = {
+    type: 'generic',
+    billingAccountId: 1,
+    name: 'test1',
+    description: 'test project1',
+    status: 'draft',
+    details: {},
+    createdBy: 1,
+    updatedBy: 1,
+    lastActivityAt: 1,
+    lastActivityUserId: '1',
+  };
   let productTemplateId;
   beforeEach((done) => {
     // mocks
     testUtil.clearDb()
-      .then(() => models.Project.create({
-        type: 'generic',
-        billingAccountId: 1,
-        name: 'test1',
-        description: 'test project1',
-        status: 'draft',
-        details: {},
-        createdBy: 1,
-        updatedBy: 1,
-        lastActivityAt: 1,
-        lastActivityUserId: '1',
-      }).then((p) => {
+      .then(() => models.Project.create(project).then((p) => {
         projectId = p.id;
         projectName = p.name;
           // create members
@@ -454,6 +461,92 @@ describe('Project Phases', () => {
             });
           }
         });
+      });
+    });
+
+    describe('RabbitMQ Message topic', () => {
+      let createMessageSpy;
+      let publishSpy;
+      let sandbox;
+
+      before((done) => {
+            // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
+        testUtil.wait(done);
+      });
+
+      beforeEach(async (done) => {
+        sandbox = sinon.sandbox.create();
+        server.services.pubsub = new RabbitMQService(server.logger);
+
+        // initialize RabbitMQ
+        server.services.pubsub.init(
+          config.get('rabbitmqURL'),
+          config.get('pubsubExchangeName'),
+          config.get('pubsubQueueName'),
+        );
+
+        // add project to ES index
+        await server.services.es.index({
+          index: ES_PROJECT_INDEX,
+          type: ES_PROJECT_TYPE,
+          id: projectId,
+          body: {
+            doc: project,
+          },
+        });
+
+        testUtil.wait(() => {
+          publishSpy = sandbox.spy(server.services.pubsub, 'publish');
+          createMessageSpy = sandbox.spy(messageService, 'createTopic');
+          done();
+        });
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should send message topic when phase added', (done) => {
+        const mockHttpClient = _.merge(testUtil.mockHttpClient, {
+          post: () => Promise.resolve({
+            status: 200,
+            data: {
+              id: 'requesterId',
+              version: 'v3',
+              result: {
+                success: true,
+                status: 200,
+                content: {},
+              },
+            },
+          }),
+        });
+        sandbox.stub(messageService, 'getClient', () => mockHttpClient);
+        request(server)
+            .post(`/v4/projects/${projectId}/phases/`)
+            .set({
+              Authorization: `Bearer ${testUtil.jwts.copilot}`,
+            })
+            .send({ param: body })
+            .expect('Content-Type', /json/)
+            .expect(201)
+            .end((err) => {
+              if (err) {
+                done(err);
+              } else {
+                testUtil.wait(() => {
+                  publishSpy.calledOnce.should.be.true;
+                  publishSpy.calledWith('project.phase.added').should.be.true;
+                  createMessageSpy.calledOnce.should.be.true;
+                  createMessageSpy.calledWith(sinon.match({ reference: 'project',
+                    referenceId: '1',
+                    tag: 'phase#1',
+                    title: 'test project phase',
+                  })).should.be.true;
+                  done();
+                });
+              }
+            });
       });
     });
   });

--- a/src/routes/phases/create.spec.js
+++ b/src/routes/phases/create.spec.js
@@ -10,6 +10,7 @@ import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
 import messageService from '../../services/messageService';
 import RabbitMQService from '../../services/rabbitmq';
+import mockRabbitMQ from '../../tests/mockRabbitMQ';
 import {
   BUS_API_EVENT,
 } from '../../constants';
@@ -504,6 +505,7 @@ describe('Project Phases', () => {
 
       afterEach(() => {
         sandbox.restore();
+        mockRabbitMQ(server);
       });
 
       it('should send message topic when phase added', (done) => {

--- a/src/routes/phases/create.spec.js
+++ b/src/routes/phases/create.spec.js
@@ -470,8 +470,8 @@ describe('Project Phases', () => {
       let publishSpy;
       let sandbox;
 
-      before((done) => {
-            // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
+      before(async (done) => {
+        // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
         testUtil.wait(done);
       });
 
@@ -505,6 +505,9 @@ describe('Project Phases', () => {
 
       afterEach(() => {
         sandbox.restore();
+      });
+
+      after(() => {
         mockRabbitMQ(server);
       });
 

--- a/src/routes/phases/delete.js
+++ b/src/routes/phases/delete.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 import { middleware as tcMiddleware } from 'tc-core-library-js';
 import models from '../../models';
-import { EVENT } from '../../constants';
+import { EVENT, TIMELINE_REFERENCES } from '../../constants';
 
 const permissions = tcMiddleware.permissions;
 
@@ -40,7 +40,7 @@ module.exports = [
         // Send events to buses
         req.app.services.pubsub.publish(
           EVENT.ROUTING_KEY.PROJECT_PHASE_REMOVED,
-          deleted,
+          { deleted, route: TIMELINE_REFERENCES.PHASE },
           { correlationId: req.id },
         );
         req.app.emit(EVENT.ROUTING_KEY.PROJECT_PHASE_REMOVED, { req, deleted });
@@ -49,4 +49,3 @@ module.exports = [
       }).catch(err => next(err));
   },
 ];
-

--- a/src/routes/phases/delete.spec.js
+++ b/src/routes/phases/delete.spec.js
@@ -291,7 +291,7 @@ describe('Project Phases', () => {
       let publishSpy;
       let sandbox;
 
-      before((done) => {
+      before(async (done) => {
         // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
         testUtil.wait(done);
       });
@@ -328,6 +328,9 @@ describe('Project Phases', () => {
 
       afterEach(() => {
         sandbox.restore();
+      });
+
+      after(() => {
         mockRabbitMQ(server);
       });
 

--- a/src/routes/phases/delete.spec.js
+++ b/src/routes/phases/delete.spec.js
@@ -10,6 +10,7 @@ import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
 import messageService from '../../services/messageService';
 import RabbitMQService from '../../services/rabbitmq';
+import mockRabbitMQ from '../../tests/mockRabbitMQ';
 import {
   BUS_API_EVENT,
 } from '../../constants';
@@ -320,13 +321,14 @@ describe('Project Phases', () => {
           publishSpy = sandbox.spy(server.services.pubsub, 'publish');
           deleteTopicSpy = sandbox.spy(messageService, 'deleteTopic');
           deletePostsSpy = sandbox.spy(messageService, 'deletePosts');
-          sandbox.stub(messageService, 'getPhaseTopic', () => Promise.resolve(topic));
+          sandbox.stub(messageService, 'getTopicByTag', () => Promise.resolve(topic));
           done();
         });
       });
 
       afterEach(() => {
         sandbox.restore();
+        mockRabbitMQ(server);
       });
 
       it('should send message topic when phase deleted', (done) => {

--- a/src/routes/phases/delete.spec.js
+++ b/src/routes/phases/delete.spec.js
@@ -3,14 +3,19 @@ import _ from 'lodash';
 import request from 'supertest';
 import sinon from 'sinon';
 import chai from 'chai';
+import config from 'config';
 import server from '../../app';
 import models from '../../models';
 import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
-
+import messageService from '../../services/messageService';
+import RabbitMQService from '../../services/rabbitmq';
 import {
   BUS_API_EVENT,
 } from '../../constants';
+
+const ES_PROJECT_INDEX = config.get('elasticsearchConfig.indexName');
+const ES_PROJECT_TYPE = config.get('elasticsearchConfig.docType');
 
 const expectAfterDelete = (projectId, id, err, next) => {
   if (err) throw err;
@@ -70,22 +75,32 @@ describe('Project Phases', () => {
     lastName: 'lName',
     email: 'some@abc.com',
   };
+  const project = {
+    type: 'generic',
+    billingAccountId: 1,
+    name: 'test1',
+    description: 'test project1',
+    status: 'draft',
+    details: {},
+    createdBy: 1,
+    updatedBy: 1,
+    lastActivityAt: 1,
+    lastActivityUserId: '1',
+  };
+  const topic = {
+    id: 1,
+    title: 'test project phase',
+    posts:
+    [{ id: 1,
+      type: 'post',
+      body: 'body',
+    }],
+  };
   beforeEach((done) => {
     // mocks
     testUtil.clearDb()
         .then(() => {
-          models.Project.create({
-            type: 'generic',
-            billingAccountId: 1,
-            name: 'test1',
-            description: 'test project1',
-            status: 'draft',
-            details: {},
-            createdBy: 1,
-            updatedBy: 1,
-            lastActivityAt: 1,
-            lastActivityUserId: '1',
-          }).then((p) => {
+          models.Project.create(project).then((p) => {
             projectId = p.id;
             projectName = p.name;
             // create members
@@ -266,6 +281,79 @@ describe('Project Phases', () => {
             });
           }
         });
+      });
+    });
+
+    describe('RabbitMQ Message topic', () => {
+      let deleteTopicSpy;
+      let deletePostsSpy;
+      let publishSpy;
+      let sandbox;
+
+      before((done) => {
+        // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
+        testUtil.wait(done);
+      });
+
+      beforeEach(async (done) => {
+        sandbox = sinon.sandbox.create();
+        server.services.pubsub = new RabbitMQService(server.logger);
+
+        // initialize RabbitMQ
+        server.services.pubsub.init(
+          config.get('rabbitmqURL'),
+          config.get('pubsubExchangeName'),
+          config.get('pubsubQueueName'),
+        );
+
+        // add project to ES index
+        await server.services.es.index({
+          index: ES_PROJECT_INDEX,
+          type: ES_PROJECT_TYPE,
+          id: projectId,
+          body: {
+            doc: _.assign(project, { phases: [_.assign(body, { id: phaseId, projectId })] }),
+          },
+        });
+
+        testUtil.wait(() => {
+          publishSpy = sandbox.spy(server.services.pubsub, 'publish');
+          deleteTopicSpy = sandbox.spy(messageService, 'deleteTopic');
+          deletePostsSpy = sandbox.spy(messageService, 'deletePosts');
+          sandbox.stub(messageService, 'getPhaseTopic', () => Promise.resolve(topic));
+          done();
+        });
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should send message topic when phase deleted', (done) => {
+        const mockHttpClient = _.merge(testUtil.mockHttpClient, {
+          delete: () => Promise.resolve(true),
+        });
+        sandbox.stub(messageService, 'getClient', () => mockHttpClient);
+        request(server)
+            .delete(`/v4/projects/${projectId}/phases/${phaseId}`)
+            .set({
+              Authorization: `Bearer ${testUtil.jwts.admin}`,
+            })
+            .expect(204)
+            .end((err) => {
+              if (err) {
+                done(err);
+              } else {
+                testUtil.wait(() => {
+                  publishSpy.calledOnce.should.be.true;
+                  publishSpy.firstCall.calledWith('project.phase.removed').should.be.true;
+                  deleteTopicSpy.calledOnce.should.be.true;
+                  deleteTopicSpy.calledWith(topic.id).should.be.true;
+                  deletePostsSpy.calledWith(topic.id).should.be.true;
+                  done();
+                });
+              }
+            });
       });
     });
   });

--- a/src/routes/phases/update.js
+++ b/src/routes/phases/update.js
@@ -6,7 +6,7 @@ import Sequelize from 'sequelize';
 import { middleware as tcMiddleware } from 'tc-core-library-js';
 import models from '../../models';
 import util from '../../util';
-import { EVENT, ROUTES } from '../../constants';
+import { EVENT, ROUTES, TIMELINE_REFERENCES } from '../../constants';
 
 
 const permissions = tcMiddleware.permissions;
@@ -156,7 +156,7 @@ module.exports = [
         // emit original and updated project phase information
         req.app.services.pubsub.publish(
           EVENT.ROUTING_KEY.PROJECT_PHASE_UPDATED,
-          { original: previousValue, updated, allPhases },
+          { original: previousValue, updated, allPhases, route: TIMELINE_REFERENCES.PHASE },
           { correlationId: req.id },
         );
         req.app.emit(EVENT.ROUTING_KEY.PROJECT_PHASE_UPDATED, {

--- a/src/routes/phases/update.spec.js
+++ b/src/routes/phases/update.spec.js
@@ -2,15 +2,20 @@
 import _ from 'lodash';
 import sinon from 'sinon';
 import chai from 'chai';
+import config from 'config';
 import request from 'supertest';
 import server from '../../app';
 import models from '../../models';
 import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
-
+import messageService from '../../services/messageService';
+import RabbitMQService from '../../services/rabbitmq';
 import {
   BUS_API_EVENT,
 } from '../../constants';
+
+const ES_PROJECT_INDEX = config.get('elasticsearchConfig.indexName');
+const ES_PROJECT_TYPE = config.get('elasticsearchConfig.docType');
 
 const should = chai.should();
 
@@ -75,22 +80,32 @@ describe('Project Phases', () => {
     lastName: 'lName',
     email: 'some@abc.com',
   };
+  const project = {
+    type: 'generic',
+    billingAccountId: 1,
+    name: 'test1',
+    description: 'test project1',
+    status: 'draft',
+    details: {},
+    createdBy: 1,
+    updatedBy: 1,
+    lastActivityAt: 1,
+    lastActivityUserId: '1',
+  };
+  const topic = {
+    id: 1,
+    title: 'test project phase',
+    posts:
+    [{ id: 1,
+      type: 'post',
+      body: 'body',
+    }],
+  };
   beforeEach((done) => {
     // mocks
     testUtil.clearDb()
       .then(() => {
-        models.Project.create({
-          type: 'generic',
-          billingAccountId: 1,
-          name: 'test1',
-          description: 'test project1',
-          status: 'draft',
-          details: {},
-          createdBy: 1,
-          updatedBy: 1,
-          lastActivityAt: 1,
-          lastActivityUserId: '1',
-        }).then((p) => {
+        models.Project.create(project).then((p) => {
           projectId = p.id;
           projectName = p.name;
           // create members
@@ -633,6 +648,92 @@ describe('Project Phases', () => {
             });
           }
         });
+      });
+    });
+
+    describe('RabbitMQ Message topic', () => {
+      let updateMessageSpy;
+      let publishSpy;
+      let sandbox;
+
+      before((done) => {
+        // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
+        testUtil.wait(done);
+      });
+
+      beforeEach(async (done) => {
+        sandbox = sinon.sandbox.create();
+        server.services.pubsub = new RabbitMQService(server.logger);
+
+        // initialize RabbitMQ
+        server.services.pubsub.init(
+          config.get('rabbitmqURL'),
+          config.get('pubsubExchangeName'),
+          config.get('pubsubQueueName'),
+        );
+
+        // add project to ES index
+        await server.services.es.index({
+          index: ES_PROJECT_INDEX,
+          type: ES_PROJECT_TYPE,
+          id: projectId,
+          body: {
+            doc: _.assign(project, { phases: [_.assign(body, { id: phaseId, projectId })] }),
+          },
+        });
+
+        testUtil.wait(() => {
+          publishSpy = sandbox.spy(server.services.pubsub, 'publish');
+          updateMessageSpy = sandbox.spy(messageService, 'updateTopic');
+          sandbox.stub(messageService, 'getPhaseTopic', () => Promise.resolve(topic));
+          done();
+        });
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should send message topic when phase Updated', (done) => {
+        const mockHttpClient = _.merge(testUtil.mockHttpClient, {
+          post: () => Promise.resolve({
+            status: 200,
+            data: {
+              id: 'requesterId',
+              version: 'v3',
+              result: {
+                success: true,
+                status: 200,
+                content: {},
+              },
+            },
+          }),
+        });
+        sandbox.stub(messageService, 'getClient', () => mockHttpClient);
+        request(server)
+            .patch(`/v4/projects/${projectId}/phases/${phaseId}`)
+            .set({
+              Authorization: `Bearer ${testUtil.jwts.admin}`,
+            })
+            .send({ param: _.assign(updateBody, { budget: 123 }) })
+            .expect('Content-Type', /json/)
+            .expect(200)
+            .end((err) => {
+              if (err) {
+                done(err);
+              } else {
+                testUtil.wait(() => {
+                  publishSpy.calledOnce.should.be.true;
+                  publishSpy.calledWith('project.phase.updated').should.be.true;
+                  updateMessageSpy.calledOnce.should.be.true;
+                  updateMessageSpy.calledWith(topic.id, sinon.match({
+                    title: updateBody.name,
+                    postId: topic.posts[0].id,
+                    content: topic.posts[0].body })).should.be.true;
+                  done();
+                });
+              }
+            });
       });
     });
   });

--- a/src/routes/phases/update.spec.js
+++ b/src/routes/phases/update.spec.js
@@ -10,6 +10,7 @@ import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
 import messageService from '../../services/messageService';
 import RabbitMQService from '../../services/rabbitmq';
+import mockRabbitMQ from '../../tests/mockRabbitMQ';
 import {
   BUS_API_EVENT,
 } from '../../constants';
@@ -685,13 +686,14 @@ describe('Project Phases', () => {
         testUtil.wait(() => {
           publishSpy = sandbox.spy(server.services.pubsub, 'publish');
           updateMessageSpy = sandbox.spy(messageService, 'updateTopic');
-          sandbox.stub(messageService, 'getPhaseTopic', () => Promise.resolve(topic));
+          sandbox.stub(messageService, 'getTopicByTag', () => Promise.resolve(topic));
           done();
         });
       });
 
       afterEach(() => {
         sandbox.restore();
+        mockRabbitMQ(server);
       });
 
       it('should send message topic when phase Updated', (done) => {

--- a/src/routes/phases/update.spec.js
+++ b/src/routes/phases/update.spec.js
@@ -657,7 +657,7 @@ describe('Project Phases', () => {
       let publishSpy;
       let sandbox;
 
-      before((done) => {
+      before(async (done) => {
         // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
         testUtil.wait(done);
       });
@@ -693,6 +693,9 @@ describe('Project Phases', () => {
 
       afterEach(() => {
         sandbox.restore();
+      });
+
+      after(() => {
         mockRabbitMQ(server);
       });
 

--- a/src/routes/works/create.js
+++ b/src/routes/works/create.js
@@ -8,7 +8,7 @@ import Sequelize from 'sequelize';
 
 import models from '../../models';
 import util from '../../util';
-import { EVENT } from '../../constants';
+import { EVENT, TIMELINE_REFERENCES } from '../../constants';
 
 const permissions = require('tc-core-library-js').middleware.permissions;
 
@@ -138,7 +138,7 @@ module.exports = [
         // Send events to buses
         req.log.debug('Sending event to RabbitMQ bus for project phase %d', newProjectPhase.id);
         req.app.services.pubsub.publish(EVENT.ROUTING_KEY.PROJECT_PHASE_ADDED,
-        newProjectPhase,
+        { added: newProjectPhase, route: TIMELINE_REFERENCES.WORK },
         { correlationId: req.id },
         );
         req.log.debug('Sending event to Kafka bus for project phase %d', newProjectPhase.id);

--- a/src/routes/works/create.spec.js
+++ b/src/routes/works/create.spec.js
@@ -340,8 +340,8 @@ describe('CREATE work', () => {
       let publishSpy;
       let sandbox;
 
-      before((done) => {
-            // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
+      before(async (done) => {
+        // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
         testUtil.wait(done);
       });
 
@@ -375,6 +375,9 @@ describe('CREATE work', () => {
 
       afterEach(() => {
         sandbox.restore();
+      });
+
+      after(() => {
         mockRabbitMQ(server);
       });
 

--- a/src/routes/works/create.spec.js
+++ b/src/routes/works/create.spec.js
@@ -14,6 +14,7 @@ import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
 import messageService from '../../services/messageService';
 import RabbitMQService from '../../services/rabbitmq';
+import mockRabbitMQ from '../../tests/mockRabbitMQ';
 import { BUS_API_EVENT } from '../../constants';
 
 const ES_PROJECT_INDEX = config.get('elasticsearchConfig.indexName');
@@ -374,6 +375,7 @@ describe('CREATE work', () => {
 
       afterEach(() => {
         sandbox.restore();
+        mockRabbitMQ(server);
       });
 
       it('should send message topic when work added', (done) => {

--- a/src/routes/works/create.spec.js
+++ b/src/routes/works/create.spec.js
@@ -7,12 +7,17 @@ import _ from 'lodash';
 import chai from 'chai';
 import sinon from 'sinon';
 import request from 'supertest';
-
+import config from 'config';
 import models from '../../models';
 import server from '../../app';
 import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
+import messageService from '../../services/messageService';
+import RabbitMQService from '../../services/rabbitmq';
 import { BUS_API_EVENT } from '../../constants';
+
+const ES_PROJECT_INDEX = config.get('elasticsearchConfig.indexName');
+const ES_PROJECT_TYPE = config.get('elasticsearchConfig.docType');
 
 const should = chai.should();
 
@@ -45,6 +50,18 @@ describe('CREATE work', () => {
     firstName: 'fname',
     lastName: 'lName',
     email: 'some@abc.com',
+  };
+  const project = {
+    type: 'generic',
+    billingAccountId: 1,
+    name: 'test1',
+    description: 'test project1',
+    status: 'draft',
+    details: {},
+    createdBy: 1,
+    updatedBy: 1,
+    lastActivityAt: 1,
+    lastActivityUserId: '1',
   };
 
   beforeEach((done) => {
@@ -82,22 +99,10 @@ describe('CREATE work', () => {
           })
           .then(() => {
             // Create projects
-            models.Project.create({
-              type: 'generic',
-              billingAccountId: 1,
-              name: 'test1',
-              description: 'test project1',
-              status: 'draft',
-              templateId: template.id,
-              details: {},
-              createdBy: 1,
-              updatedBy: 1,
-              lastActivityAt: 1,
-              lastActivityUserId: '1',
-            })
-            .then((project) => {
-              projectId = project.id;
-              projectName = project.name;
+            models.Project.create(_.assign(project, { templateId: template.id }))
+            .then((_project) => {
+              projectId = _project.id;
+              projectName = _project.name;
               models.WorkStream.create({
                 name: 'Work Stream',
                 type: 'generic',
@@ -326,6 +331,86 @@ describe('CREATE work', () => {
             });
           }
         });
+      });
+    });
+
+    describe('RabbitMQ Message topic', () => {
+      let createMessageSpy;
+      let publishSpy;
+      let sandbox;
+
+      before((done) => {
+            // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
+        testUtil.wait(done);
+      });
+
+      beforeEach(async (done) => {
+        sandbox = sinon.sandbox.create();
+        server.services.pubsub = new RabbitMQService(server.logger);
+
+        // initialize RabbitMQ
+        server.services.pubsub.init(
+          config.get('rabbitmqURL'),
+          config.get('pubsubExchangeName'),
+          config.get('pubsubQueueName'),
+        );
+
+        // add project to ES index
+        await server.services.es.index({
+          index: ES_PROJECT_INDEX,
+          type: ES_PROJECT_TYPE,
+          id: projectId,
+          body: {
+            doc: project,
+          },
+        });
+
+        testUtil.wait(() => {
+          publishSpy = sandbox.spy(server.services.pubsub, 'publish');
+          createMessageSpy = sandbox.spy(messageService, 'createTopic');
+          done();
+        });
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should send message topic when work added', (done) => {
+        const mockHttpClient = _.merge(testUtil.mockHttpClient, {
+          post: () => Promise.resolve({
+            status: 200,
+            data: {
+              id: 'requesterId',
+              version: 'v3',
+              result: {
+                success: true,
+                status: 200,
+                content: {},
+              },
+            },
+          }),
+        });
+        sandbox.stub(messageService, 'getClient', () => mockHttpClient);
+        request(server)
+            .post(`/v4/projects/${projectId}/workstreams/${workStreamId}/works`)
+            .set({
+              Authorization: `Bearer ${testUtil.jwts.connectAdmin}`,
+            })
+            .send(body)
+            .expect(201)
+            .end((err) => {
+              if (err) {
+                done(err);
+              } else {
+                testUtil.wait(() => {
+                  publishSpy.calledOnce.should.be.true;
+                  publishSpy.calledWith('project.phase.added').should.be.true;
+                  createMessageSpy.calledTwice.should.be.true;
+                  done();
+                });
+              }
+            });
       });
     });
   });

--- a/src/routes/works/delete.js
+++ b/src/routes/works/delete.js
@@ -5,7 +5,7 @@ import validate from 'express-validation';
 import Joi from 'joi';
 import { middleware as tcMiddleware } from 'tc-core-library-js';
 import models from '../../models';
-import { EVENT } from '../../constants';
+import { EVENT, TIMELINE_REFERENCES } from '../../constants';
 
 const permissions = tcMiddleware.permissions;
 
@@ -62,7 +62,7 @@ module.exports = [
       // Send events to buses
       req.app.services.pubsub.publish(
         EVENT.ROUTING_KEY.PROJECT_PHASE_REMOVED,
-        deleted,
+        { deleted, route: TIMELINE_REFERENCES.WORK },
         { correlationId: req.id },
       );
       req.app.emit(EVENT.ROUTING_KEY.PROJECT_PHASE_REMOVED, { req, deleted });

--- a/src/routes/works/delete.spec.js
+++ b/src/routes/works/delete.spec.js
@@ -13,6 +13,7 @@ import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
 import messageService from '../../services/messageService';
 import RabbitMQService from '../../services/rabbitmq';
+import mockRabbitMQ from '../../tests/mockRabbitMQ';
 import { BUS_API_EVENT } from '../../constants';
 
 const ES_PROJECT_INDEX = config.get('elasticsearchConfig.indexName');
@@ -354,13 +355,14 @@ describe('DELETE work', () => {
           publishSpy = sandbox.spy(server.services.pubsub, 'publish');
           deleteTopicSpy = sandbox.spy(messageService, 'deleteTopic');
           deletePostsSpy = sandbox.spy(messageService, 'deletePosts');
-          sandbox.stub(messageService, 'getPhaseTopic', () => Promise.resolve(topic));
+          sandbox.stub(messageService, 'getTopicByTag', () => Promise.resolve(topic));
           done();
         });
       });
 
       afterEach(() => {
         sandbox.restore();
+        mockRabbitMQ(server);
       });
 
       it('should send message topic when work deleted', (done) => {

--- a/src/routes/works/delete.spec.js
+++ b/src/routes/works/delete.spec.js
@@ -2,15 +2,21 @@
 /**
  * Tests for delete.js
  */
+import _ from 'lodash';
 import request from 'supertest';
 import chai from 'chai';
 import sinon from 'sinon';
-
+import config from 'config';
 import models from '../../models';
 import server from '../../app';
 import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
+import messageService from '../../services/messageService';
+import RabbitMQService from '../../services/rabbitmq';
 import { BUS_API_EVENT } from '../../constants';
+
+const ES_PROJECT_INDEX = config.get('elasticsearchConfig.indexName');
+const ES_PROJECT_TYPE = config.get('elasticsearchConfig.docType');
 
 chai.should();
 
@@ -60,7 +66,27 @@ describe('DELETE work', () => {
     lastName: 'lName',
     email: 'some@abc.com',
   };
-
+  const project = {
+    type: 'generic',
+    billingAccountId: 1,
+    name: 'test1',
+    description: 'test project1',
+    status: 'draft',
+    details: {},
+    createdBy: 1,
+    updatedBy: 1,
+    lastActivityAt: 1,
+    lastActivityUserId: '1',
+  };
+  const topic = {
+    id: 1,
+    title: 'test project phase',
+    posts:
+    [{ id: 1,
+      type: 'post',
+      body: 'body',
+    }],
+  };
   beforeEach((done) => {
     testUtil.clearDb()
       .then(() => {
@@ -96,22 +122,10 @@ describe('DELETE work', () => {
           })
           .then(() => {
             // Create projects
-            models.Project.create({
-              type: 'generic',
-              billingAccountId: 1,
-              name: 'test1',
-              description: 'test project1',
-              status: 'draft',
-              templateId: template.id,
-              details: {},
-              createdBy: 1,
-              updatedBy: 1,
-              lastActivityAt: 1,
-              lastActivityUserId: '1',
-            })
-            .then((project) => {
-              projectId = project.id;
-              projectName = project.name;
+            models.Project.create(_.assign(project, { templateId: template.id }))
+            .then((_project) => {
+              projectId = _project.id;
+              projectName = _project.name;
               models.WorkStream.create({
                 name: 'Work Stream',
                 type: 'generic',
@@ -288,6 +302,91 @@ describe('DELETE work', () => {
             });
           }
         });
+      });
+    });
+
+    describe('RabbitMQ Message topic', () => {
+      let deleteTopicSpy;
+      let deletePostsSpy;
+      let publishSpy;
+      let sandbox;
+
+      before((done) => {
+        // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
+        testUtil.wait(done);
+      });
+
+      beforeEach(async (done) => {
+        sandbox = sinon.sandbox.create();
+        server.services.pubsub = new RabbitMQService(server.logger);
+
+        // initialize RabbitMQ
+        server.services.pubsub.init(
+          config.get('rabbitmqURL'),
+          config.get('pubsubExchangeName'),
+          config.get('pubsubQueueName'),
+        );
+
+        // add project to ES index
+        await server.services.es.index({
+          index: ES_PROJECT_INDEX,
+          type: ES_PROJECT_TYPE,
+          id: projectId,
+          body: {
+            doc: _.assign(project, { phases: [_.assign({
+              name: 'test project phase',
+              status: 'active',
+              startDate: '2018-05-15T00:00:00Z',
+              endDate: '2018-05-15T12:00:00Z',
+              budget: 20.0,
+              progress: 1.23456,
+              details: {
+                message: 'This can be any json',
+              },
+              createdBy: 1,
+              updatedBy: 1,
+              projectId,
+            }, { id: workId, projectId })] }),
+          },
+        });
+
+        testUtil.wait(() => {
+          publishSpy = sandbox.spy(server.services.pubsub, 'publish');
+          deleteTopicSpy = sandbox.spy(messageService, 'deleteTopic');
+          deletePostsSpy = sandbox.spy(messageService, 'deletePosts');
+          sandbox.stub(messageService, 'getPhaseTopic', () => Promise.resolve(topic));
+          done();
+        });
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should send message topic when work deleted', (done) => {
+        const mockHttpClient = _.merge(testUtil.mockHttpClient, {
+          delete: () => Promise.resolve(true),
+        });
+        sandbox.stub(messageService, 'getClient', () => mockHttpClient);
+        request(server)
+            .delete(`/v4/projects/${projectId}/workstreams/${workStreamId}/works/${workId}`)
+            .set({
+              Authorization: `Bearer ${testUtil.jwts.admin}`,
+            })
+            .expect(204)
+            .end((err) => {
+              if (err) {
+                done(err);
+              } else {
+                testUtil.wait(() => {
+                  publishSpy.calledOnce.should.be.true;
+                  publishSpy.calledWith('project.phase.removed').should.be.true;
+                  deleteTopicSpy.calledTwice.should.be.true;
+                  deletePostsSpy.calledTwice.should.be.true;
+                  done();
+                });
+              }
+            });
       });
     });
   });

--- a/src/routes/works/delete.spec.js
+++ b/src/routes/works/delete.spec.js
@@ -312,7 +312,7 @@ describe('DELETE work', () => {
       let publishSpy;
       let sandbox;
 
-      before((done) => {
+      before(async (done) => {
         // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
         testUtil.wait(done);
       });
@@ -362,6 +362,9 @@ describe('DELETE work', () => {
 
       afterEach(() => {
         sandbox.restore();
+      });
+
+      after(() => {
         mockRabbitMQ(server);
       });
 

--- a/src/routes/works/update.js
+++ b/src/routes/works/update.js
@@ -8,7 +8,7 @@ import Sequelize from 'sequelize';
 import { middleware as tcMiddleware } from 'tc-core-library-js';
 import models from '../../models';
 import util from '../../util';
-import { EVENT, ROUTES } from '../../constants';
+import { EVENT, ROUTES, TIMELINE_REFERENCES } from '../../constants';
 
 const permissions = tcMiddleware.permissions;
 
@@ -175,7 +175,7 @@ module.exports = [
         // emit original and updated project phase information
         req.app.services.pubsub.publish(
           EVENT.ROUTING_KEY.PROJECT_PHASE_UPDATED,
-          { original: previousValue, updated, allPhases },
+          { original: previousValue, updated, allPhases, route: TIMELINE_REFERENCES.WORK },
           { correlationId: req.id },
         );
         req.app.emit(EVENT.ROUTING_KEY.PROJECT_PHASE_UPDATED, {

--- a/src/routes/works/update.spec.js
+++ b/src/routes/works/update.spec.js
@@ -6,12 +6,17 @@ import _ from 'lodash';
 import chai from 'chai';
 import request from 'supertest';
 import sinon from 'sinon';
-
+import config from 'config';
 import models from '../../models';
 import server from '../../app';
 import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
+import messageService from '../../services/messageService';
+import RabbitMQService from '../../services/rabbitmq';
 import { BUS_API_EVENT } from '../../constants';
+
+const ES_PROJECT_INDEX = config.get('elasticsearchConfig.indexName');
+const ES_PROJECT_TYPE = config.get('elasticsearchConfig.docType');
 
 const should = chai.should();
 
@@ -78,7 +83,27 @@ describe('UPDATE work', () => {
     lastName: 'lName',
     email: 'some@abc.com',
   };
-
+  const project = {
+    type: 'generic',
+    billingAccountId: 1,
+    name: 'test1',
+    description: 'test project1',
+    status: 'draft',
+    details: {},
+    createdBy: 1,
+    updatedBy: 1,
+    lastActivityAt: 1,
+    lastActivityUserId: '1',
+  };
+  const topic = {
+    id: 1,
+    title: 'test project phase',
+    posts:
+    [{ id: 1,
+      type: 'post',
+      body: 'body',
+    }],
+  };
   beforeEach((done) => {
     testUtil.clearDb()
       .then(() => {
@@ -114,22 +139,10 @@ describe('UPDATE work', () => {
           })
           .then(() => {
             // Create projects
-            models.Project.create({
-              type: 'generic',
-              billingAccountId: 1,
-              name: 'test1',
-              description: 'test project1',
-              status: 'draft',
-              templateId: template.id,
-              details: {},
-              createdBy: 1,
-              updatedBy: 1,
-              lastActivityAt: 1,
-              lastActivityUserId: '1',
-            })
-            .then((project) => {
-              projectId = project.id;
-              projectName = project.name;
+            models.Project.create(_.assign(project, { templateId: template.id }))
+            .then((_project) => {
+              projectId = _project.id;
+              projectName = _project.name;
               models.WorkStream.create({
                 name: 'Work Stream',
                 type: 'generic',
@@ -630,6 +643,88 @@ describe('UPDATE work', () => {
             });
           }
         });
+      });
+    });
+
+    describe('RabbitMQ Message topic', () => {
+      let updateMessageSpy;
+      let publishSpy;
+      let sandbox;
+
+      before((done) => {
+        // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
+        testUtil.wait(done);
+      });
+
+      beforeEach(async (done) => {
+        sandbox = sinon.sandbox.create();
+        server.services.pubsub = new RabbitMQService(server.logger);
+
+        // initialize RabbitMQ
+        server.services.pubsub.init(
+          config.get('rabbitmqURL'),
+          config.get('pubsubExchangeName'),
+          config.get('pubsubQueueName'),
+        );
+
+        // add project to ES index
+        await server.services.es.index({
+          index: ES_PROJECT_INDEX,
+          type: ES_PROJECT_TYPE,
+          id: projectId,
+          body: {
+            doc: _.assign(project, { phases: [_.assign(body, { id: workId, projectId })] }),
+          },
+        });
+
+        testUtil.wait(() => {
+          publishSpy = sandbox.spy(server.services.pubsub, 'publish');
+          updateMessageSpy = sandbox.spy(messageService, 'updateTopic');
+          sandbox.stub(messageService, 'getPhaseTopic', () => Promise.resolve(topic));
+          done();
+        });
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should send message topic when work updated', (done) => {
+        const mockHttpClient = _.merge(testUtil.mockHttpClient, {
+          post: () => Promise.resolve({
+            status: 200,
+            data: {
+              id: 'requesterId',
+              version: 'v3',
+              result: {
+                success: true,
+                status: 200,
+                content: {},
+              },
+            },
+          }),
+        });
+        sandbox.stub(messageService, 'getClient', () => mockHttpClient);
+        request(server)
+            .patch(`/v4/projects/${projectId}/workstreams/${workStreamId}/works/${workId}`)
+            .set({
+              Authorization: `Bearer ${testUtil.jwts.admin}`,
+            })
+            .send({ param: _.assign(updateBody, { budget: 123 }) })
+            .expect('Content-Type', /json/)
+            .expect(200)
+            .end((err) => {
+              if (err) {
+                done(err);
+              } else {
+                testUtil.wait(() => {
+                  publishSpy.calledOnce.should.be.true;
+                  publishSpy.calledWith('project.phase.updated').should.be.true;
+                  updateMessageSpy.calledTwice.should.be.true;
+                  done();
+                });
+              }
+            });
       });
     });
   });

--- a/src/routes/works/update.spec.js
+++ b/src/routes/works/update.spec.js
@@ -13,6 +13,7 @@ import testUtil from '../../tests/util';
 import busApi from '../../services/busApi';
 import messageService from '../../services/messageService';
 import RabbitMQService from '../../services/rabbitmq';
+import mockRabbitMQ from '../../tests/mockRabbitMQ';
 import { BUS_API_EVENT } from '../../constants';
 
 const ES_PROJECT_INDEX = config.get('elasticsearchConfig.indexName');
@@ -680,13 +681,14 @@ describe('UPDATE work', () => {
         testUtil.wait(() => {
           publishSpy = sandbox.spy(server.services.pubsub, 'publish');
           updateMessageSpy = sandbox.spy(messageService, 'updateTopic');
-          sandbox.stub(messageService, 'getPhaseTopic', () => Promise.resolve(topic));
+          sandbox.stub(messageService, 'getTopicByTag', () => Promise.resolve(topic));
           done();
         });
       });
 
       afterEach(() => {
         sandbox.restore();
+        mockRabbitMQ(server);
       });
 
       it('should send message topic when work updated', (done) => {

--- a/src/routes/works/update.spec.js
+++ b/src/routes/works/update.spec.js
@@ -652,7 +652,7 @@ describe('UPDATE work', () => {
       let publishSpy;
       let sandbox;
 
-      before((done) => {
+      before(async (done) => {
         // Wait for 500ms in order to wait for createEvent calls from previous tests to complete
         testUtil.wait(done);
       });
@@ -688,6 +688,9 @@ describe('UPDATE work', () => {
 
       afterEach(() => {
         sandbox.restore();
+      });
+
+      after(() => {
         mockRabbitMQ(server);
       });
 

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -1,6 +1,5 @@
 import config from 'config';
 import _ from 'lodash';
-// import util from '../util';
 
 const Promise = require('bluebird');
 const axios = require('axios');
@@ -141,15 +140,17 @@ function deletePosts(topicId, postIds, logger) {
  * Fetches the topic of given phase of the project.
  *
  * @param {Integer} projectId id of the project
- * @param {Integer} phaseId id of the phase of the project
+ * @param {String} tag tag
  * @param {Object} logger object
  * @return {Promise} topic promise
  */
-function getPhaseTopic(projectId, phaseId, logger) {
+function getPhaseTopic(projectId, tag, logger) {
+  const regex = new RegExp(/(\d+)/);
+  const phaseId = regex.exec(tag)[0];
   logger.debug(`getPhaseTopic for projectId: ${projectId} phaseId: ${phaseId}`);
   return getClient(logger).then((msgClient) => {
-    logger.debug(`calling message service for fetching phaseId#${phaseId}`);
-    const encodedFilter = encodeURIComponent(`reference=project&referenceId=${projectId}&tag=phase#${phaseId}`);
+    logger.debug(`calling message service for fetching ${tag}`);
+    const encodedFilter = encodeURIComponent(`reference=project&referenceId=${projectId}&tag=${tag}`);
     return msgClient.get(`/topics/list/db?filter=${encodedFilter}`)
     .then((resp) => {
       logger.debug('Fetched phase topic', resp);
@@ -183,4 +184,5 @@ module.exports = {
   deletePosts,
   getPhaseTopic,
   deleteTopic,
+  getClient,
 };

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -144,17 +144,15 @@ function deletePosts(topicId, postIds, logger) {
  * @param {Object} logger object
  * @return {Promise} topic promise
  */
-function getPhaseTopic(projectId, tag, logger) {
-  const regex = new RegExp(/(\d+)/);
-  const phaseId = regex.exec(tag)[0];
-  logger.debug(`getPhaseTopic for projectId: ${projectId} phaseId: ${phaseId}`);
+function getTopicByTag(projectId, tag, logger) {
+  logger.debug(`getTopicByTag for projectId: ${projectId} tag: ${tag}`);
   return getClient(logger).then((msgClient) => {
     logger.debug(`calling message service for fetching ${tag}`);
     const encodedFilter = encodeURIComponent(`reference=project&referenceId=${projectId}&tag=${tag}`);
     return msgClient.get(`/topics/list/db?filter=${encodedFilter}`)
     .then((resp) => {
-      logger.debug('Fetched phase topic', resp);
       const topics = _.get(resp.data, 'result.content', []);
+      logger.debug(`Fetched ${topics.length} topics`);
       if (topics && topics.length > 0) {
         return topics[0];
       }
@@ -182,7 +180,7 @@ module.exports = {
   createTopic,
   updateTopic,
   deletePosts,
-  getPhaseTopic,
+  getTopicByTag,
   deleteTopic,
   getClient,
 };

--- a/src/tests/mockRabbitMQ.js
+++ b/src/tests/mockRabbitMQ.js
@@ -1,0 +1,18 @@
+/**
+ * Mock RabbitMQ service
+ */
+/* globals Promise */
+
+import sinon from 'sinon';
+import _ from 'lodash';
+
+module.exports = (app) => {
+  _.assign(app.services, {
+    pubsub: {
+      init: () => {},
+      publish: () => {},
+    },
+  });
+  sinon.stub(app.services.pubsub, 'init', () => Promise.resolve(true));
+  sinon.stub(app.services.pubsub, 'publish', () => Promise.resolve(true));
+};

--- a/src/tests/serviceMocks.js
+++ b/src/tests/serviceMocks.js
@@ -7,16 +7,13 @@ import _ from 'lodash';
 import config from 'config';
 import elasticsearch from 'elasticsearch';
 import util from '../util';
+import mockRabbitMQ from './mockRabbitMQ';
 
 module.exports = (app) => {
+  mockRabbitMQ(app);
+
   _.assign(app.services, {
-    pubsub: {
-      init: () => {},
-      publish: () => {},
-    },
     es: new elasticsearch.Client(_.cloneDeep(config.elasticsearchConfig)),
   });
-  sinon.stub(app.services.pubsub, 'init', () => Promise.resolve(true));
-  sinon.stub(app.services.pubsub, 'publish', () => Promise.resolve(true));
   sinon.stub(util, 'getM2MToken', () => Promise.resolve('MOCK_TOKEN'));
 };


### PR DESCRIPTION
Implementation for https://github.com/topcoder-platform/tc-project-service/issues/357

Creating 2 topics for works to show comments on Details and Requirements tabs.

Notes:
- Keep the same code base between phases and works, so later we can update the common functionality in the same place
- Implemented unit tests, to verify that for phases we create/update/delete one topic as before. And that for new work endpoints we create/update/delete two topics.

Tested it locally and also have unit tests. So I think it's safe to merge and continue testing on DEV.