### PR TITLE
fix: fix unit tests so they don’t fail randomly.

### DIFF
--- a/migrations/elasticsearch_sync.js
+++ b/migrations/elasticsearch_sync.js
@@ -703,24 +703,39 @@ function getRequestBody(indexName) {
   return result;
 }
 
-    // first delete the index if already present
-esClient.indices.delete({
-  index: ES_PROJECT_INDEX,
-  // we would want to ignore no such index error
-  ignore: [404],
-})
-.then(() => esClient.indices.create(getRequestBody(ES_PROJECT_INDEX)))
-// Re-create timeline index
-.then(() => esClient.indices.delete({ index: ES_TIMELINE_INDEX, ignore: [404] }))
-.then(() => esClient.indices.create(getRequestBody(ES_TIMELINE_INDEX)))
-// Re-create metadata index
-.then(() => esClient.indices.delete({ index: ES_METADATA_INDEX, ignore: [404] }))
-.then(() => esClient.indices.create(getRequestBody(ES_METADATA_INDEX)))
-.then(() => {
-  console.log('elasticsearch indices synced successfully');
-  process.exit();
-})
-.catch((err) => {
-  console.error('elasticsearch indices sync failed', err);
-  process.exit();
-});
+/**
+ * Sync elasticsearch indices.
+ *
+ * @returns {undefined}
+ */
+function sync() {
+      // first delete the index if already present
+  return esClient.indices.delete({
+    index: ES_PROJECT_INDEX,
+    // we would want to ignore no such index error
+    ignore: [404],
+  })
+  .then(() => esClient.indices.create(getRequestBody(ES_PROJECT_INDEX)))
+  // Re-create timeline index
+  .then(() => esClient.indices.delete({ index: ES_TIMELINE_INDEX, ignore: [404] }))
+  .then(() => esClient.indices.create(getRequestBody(ES_TIMELINE_INDEX)))
+  // Re-create metadata index
+  .then(() => esClient.indices.delete({ index: ES_METADATA_INDEX, ignore: [404] }))
+  .then(() => esClient.indices.create(getRequestBody(ES_METADATA_INDEX)));
+}
+
+if (!module.parent) {
+  sync()
+    .then(() => {
+      console.log('elasticsearch indices synced successfully');
+      process.exit();
+    })
+    .catch((err) => {
+      console.error('elasticsearch indices sync failed', err);
+      process.exit();
+    });
+}
+
+module.exports = {
+  sync,
+};

--- a/src/events/projects/index.spec.js
+++ b/src/events/projects/index.spec.js
@@ -94,6 +94,7 @@ describe('projectUpdatedKafkaHandler', () => {
 
     beforeEach(async () => {
       await testUtil.clearDb();
+      await testUtil.clearES();
       project = await models.Project.create({
         type: 'generic',
         billingAccountId: 1,

--- a/src/routes/milestoneTemplates/list.spec.js
+++ b/src/routes/milestoneTemplates/list.spec.js
@@ -113,6 +113,9 @@ const milestoneTemplates = [
 ];
 
 describe('LIST milestone template', () => {
+  before((done) => {
+    testUtil.clearES(done);
+  });
   beforeEach((done) => {
     testUtil.clearDb()
     .then(() => models.ProductTemplate.bulkCreate(productTemplates))

--- a/src/routes/milestones/delete.spec.js
+++ b/src/routes/milestones/delete.spec.js
@@ -41,6 +41,9 @@ const expectAfterDelete = (timelineId, id, err, next) => {
 };
 
 describe('DELETE milestone', () => {
+  before((done) => {
+    testUtil.clearES(done);
+  });
   beforeEach((done) => {
     testUtil.clearDb()
       .then(() => {

--- a/src/routes/productCategories/list.spec.js
+++ b/src/routes/productCategories/list.spec.js
@@ -37,7 +37,9 @@ describe('LIST product categories', () => {
       updatedBy: 1,
     },
   ];
-
+  before((done) => {
+    testUtil.clearES(done);
+  });
   beforeEach((done) => {
     testUtil.clearDb()
       .then(() => models.ProductCategory.create(productCategories[0]))

--- a/src/routes/projectMembers/get.spec.js
+++ b/src/routes/projectMembers/get.spec.js
@@ -33,6 +33,7 @@ describe('GET project member', () => {
 
   beforeEach((done) => {
     testUtil.clearDb()
+      .then(() => testUtil.clearES())
       .then(() => {
         // Create projects
         models.Project.create({

--- a/src/routes/projectTypes/list.spec.js
+++ b/src/routes/projectTypes/list.spec.js
@@ -40,6 +40,9 @@ describe('LIST project types', () => {
     },
   ];
 
+  before((done) => {
+    testUtil.clearES(done);
+  });
   beforeEach((done) => {
     testUtil.clearDb()
       .then(() => models.ProjectType.create(types[0]))

--- a/src/routes/projects/list.spec.js
+++ b/src/routes/projects/list.spec.js
@@ -126,6 +126,7 @@ describe('LIST Project', () => {
   before(function inner(done) {
     this.timeout(10000);
     testUtil.clearDb()
+      .then(() => testUtil.clearES())
       .then(() => {
         const p1 = models.Project.create({
           type: 'generic',

--- a/src/tests/util.js
+++ b/src/tests/util.js
@@ -1,11 +1,16 @@
 /* eslint-disable max-len */
 
 import models from '../models';
+import elasticsearchSync from '../../migrations/elasticsearch_sync';
 
 const jwt = require('jsonwebtoken');
 
 export default {
   clearDb: done => models.sequelize.sync({ force: true })
+      .then(() => {
+        if (done) done();
+      }),
+  clearES: done => elasticsearchSync.sync()
       .then(() => {
         if (done) done();
       }),

--- a/src/util.js
+++ b/src/util.js
@@ -397,6 +397,16 @@ _.assignIn(util, {
     } else {
       esClient = new elasticsearch.Client(_.cloneDeep(config.elasticsearchConfig));
     }
+    // during unit tests, we need to refresh the indices
+    // before making get/search requests to make sure all ES data can be visible.
+    if (process.env.NODE_ENV.toLowerCase() === 'test') {
+      esClient.originalSearch = esClient.search;
+      esClient.search = (params, cb) => esClient.indices.refresh({ index: '' })
+        .then(() => esClient.originalSearch(params, cb)); // refresh index before reply
+      esClient.originalGet = esClient.get;
+      esClient.get = (params, cb) => esClient.indices.refresh({ index: '' })
+        .then(() => esClient.originalGet(params, cb)); // refresh index before reply
+    }
     return esClient;
   },
 


### PR DESCRIPTION
ElasticSearch by default refreshes indexes at a interval of 1 second.
There are chances that some newly added or updated documents
are not available during test and some deleted documents still exist for
a while, which results in random test failures.

The solution contains two parts:
1. refreshing the indices before making get/search requests to ES server
to make sure that all ES data are visible.
2. Before some of the test cases, clear all ES data created by the previous test cases.