### PR TITLE
[PROD] Hotfix /milestone completion date

### DIFF
--- a/src/events/projects/index.spec.js
+++ b/src/events/projects/index.spec.js
@@ -111,9 +111,8 @@ describe('projectUpdatedKafkaHandler', () => {
         index: ES_PROJECT_INDEX,
         type: ES_PROJECT_TYPE,
         id: project.id,
-        body: {
-          doc: project.get({ plain: true }),
-        },
+        body: project.get({ plain: true }),
+        refresh: 'wait_for',
       });
     });
 

--- a/src/routes/milestones/update.js
+++ b/src/routes/milestones/update.js
@@ -10,7 +10,7 @@ import Sequelize from 'sequelize';
 import { middleware as tcMiddleware } from 'tc-core-library-js';
 import util from '../../util';
 import validateTimeline from '../../middlewares/validateTimeline';
-import { EVENT, MILESTONE_STATUS } from '../../constants';
+import { EVENT, MILESTONE_STATUS, ADMIN_ROLES } from '../../constants';
 import models from '../../models';
 
 const permissions = tcMiddleware.permissions;
@@ -181,6 +181,14 @@ module.exports = [
             } else {
               const apiErr = new Error('No previous status is found');
               apiErr.status = 500;
+              return Promise.reject(apiErr);
+            }
+          }
+
+          if (entityToUpdate.completionDate || entityToUpdate.actualStartDate) {
+            if (!util.hasPermission({ topcoderRoles: ADMIN_ROLES }, req.authUser)) {
+              const apiErr = new Error('You are not authorised to perform this action');
+              apiErr.status = 403;
               return Promise.reject(apiErr);
             }
           }

--- a/src/routes/milestones/update.js
+++ b/src/routes/milestones/update.js
@@ -193,8 +193,15 @@ module.exports = [
             }
           }
 
-          if (entityToUpdate.completionDate && entityToUpdate.completionDate < milestone.startDate) {
-            const apiErr = new Error('The milestone completionDate should be greater or equal than the startDate.');
+          if (
+            entityToUpdate.completionDate &&
+            (entityToUpdate.actualStartDate || milestone.actualStartDate) &&
+            moment.utc(entityToUpdate.completionDate).isBefore(
+              moment.utc(entityToUpdate.actualStartDate || milestone.actualStartDate),
+              'day',
+            )
+          ) {
+            const apiErr = new Error('The milestone completionDate should be greater or equal to actualStartDate.');
             apiErr.status = 422;
             return Promise.reject(apiErr);
           }
@@ -216,7 +223,8 @@ module.exports = [
             // if status has changed to be completed, set the compeltionDate if not provided
             if (entityToUpdate.status === MILESTONE_STATUS.COMPLETED) {
               entityToUpdate.completionDate = entityToUpdate.completionDate ? entityToUpdate.completionDate : today;
-              entityToUpdate.duration = entityToUpdate.completionDate.diff(entityToUpdate.actualStartDate, 'days') + 1;
+              entityToUpdate.duration = moment.utc(entityToUpdate.completionDate)
+                .diff(entityToUpdate.actualStartDate, 'days') + 1;
             }
             // if status has changed to be active, set the startDate to today
             if (entityToUpdate.status === MILESTONE_STATUS.ACTIVE) {
@@ -241,7 +249,8 @@ module.exports = [
 
           // if completionDate has changed
           if (!statusChanged && completionDateChanged) {
-            entityToUpdate.duration = entityToUpdate.completionDate.diff(entityToUpdate.actualStartDate, 'days') + 1;
+            entityToUpdate.duration = moment.utc(entityToUpdate.completionDate)
+              .diff(entityToUpdate.actualStartDate, 'days') + 1;
             entityToUpdate.status = MILESTONE_STATUS.COMPLETED;
           }
 

--- a/src/routes/milestones/update.spec.js
+++ b/src/routes/milestones/update.spec.js
@@ -264,7 +264,6 @@ describe('UPDATE Milestone', () => {
       param: {
         name: 'Milestone 1-updated',
         duration: 3,
-        completionDate: '2018-05-16T00:00:00.000Z',
         description: 'description-updated',
         status: 'draft',
         type: 'type1-updated',
@@ -299,6 +298,30 @@ describe('UPDATE Milestone', () => {
           Authorization: `Bearer ${testUtil.jwts.member2}`,
         })
         .send(body)
+        .expect(403, done);
+    });
+
+    it('should return 403 for non-admin member updating the completionDate', (done) => {
+      const newBody = _.cloneDeep(body);
+      newBody.param.completionDate = '2019-01-16T00:00:00.000Z';
+      request(server)
+        .patch('/v4/timelines/1/milestones/1')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.manager}`,
+        })
+        .send(newBody)
+        .expect(403, done);
+    });
+
+    it('should return 403 for non-admin member updating the actualStartDate', (done) => {
+      const newBody = _.cloneDeep(body);
+      newBody.param.actualStartDate = '2018-05-15T00:00:00.000Z';
+      request(server)
+        .patch('/v4/timelines/1/milestones/1')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.manager}`,
+        })
+        .send(newBody)
         .expect(403, done);
     });
 
@@ -490,12 +513,14 @@ describe('UPDATE Milestone', () => {
     });
 
     it('should return 200 for admin', (done) => {
+      const newBody = _.cloneDeep(body);
+      newBody.param.completionDate = '2018-05-15T00:00:00.000Z';
       request(server)
         .patch('/v4/timelines/1/milestones/1')
         .set({
           Authorization: `Bearer ${testUtil.jwts.admin}`,
         })
-        .send(body)
+        .send(newBody)
         .expect(200)
         .end((err, res) => {
           const resJson = res.body.result.content;
@@ -503,7 +528,7 @@ describe('UPDATE Milestone', () => {
           resJson.name.should.be.eql(body.param.name);
           resJson.description.should.be.eql(body.param.description);
           resJson.duration.should.be.eql(body.param.duration);
-          resJson.completionDate.should.be.eql(body.param.completionDate);
+          resJson.completionDate.should.be.eql(newBody.param.completionDate);
           resJson.status.should.be.eql(body.param.status);
           resJson.type.should.be.eql(body.param.type);
           resJson.details.should.be.eql({
@@ -1059,6 +1084,30 @@ describe('UPDATE Milestone', () => {
         .send(body)
         .expect(200)
         .end(done);
+    });
+
+    it('should return 200 for admin updating the completionDate', (done) => {
+      const newBody = _.cloneDeep(body);
+      newBody.param.completionDate = '2018-05-16T00:00:00.000Z';
+      request(server)
+        .patch('/v4/timelines/1/milestones/1')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.admin}`,
+        })
+        .send(newBody)
+        .expect(200, done);
+    });
+
+    it('should return 200 for admin updating the actualStartDate', (done) => {
+      const newBody = _.cloneDeep(body);
+      newBody.param.actualStartDate = '2018-05-15T00:00:00.000Z';
+      request(server)
+        .patch('/v4/timelines/1/milestones/1')
+        .set({
+          Authorization: `Bearer ${testUtil.jwts.admin}`,
+        })
+        .send(newBody)
+        .expect(200, done);
     });
 
     it('should return 200 for connect manager', (done) => {


### PR DESCRIPTION
Supporting fixes for Connect App ticket https://github.com/appirio-tech/connect-app/issues/3210

- only admins should be able to edit `completionDate` and `actualStartDate`
- fix issue: it was validated against `startDate` instead of `actualStartDate` so `comletionDate` couldn’t be earlier than `startDate` which is not important when there is `actualStartDate` which could be earlier
- there was another error even if `comletionDate` passes the validation: `comletionDate.diff is not a function`