### PR TITLE
[Hotfix] [PROD] es skills

### DIFF
--- a/src/events/projects/index.js
+++ b/src/events/projects/index.js
@@ -41,6 +41,10 @@ const indexProject = Promise.coroutine(function* (logger, msg) { // eslint-disab
       // removes non required fields from phase objects
       data.phases = data.phases.map(phase => _.omit(phase, ['deletedAt', 'deletedBy']));
     }
+    // TEMPORARY FIX: should fix ES mapping instead and reindex all the projects instead
+    if (typeof _.get(data, 'details.taasDefinition.team.skills') !== 'string') {
+      _.set(data, 'details.taasDefinition.team.skills', '');
+    }
     // add the record to the index
     const result = yield eClient.index({
       index: ES_PROJECT_INDEX,
@@ -91,6 +95,10 @@ const projectUpdatedHandler = Promise.coroutine(function* (logger, msg, channel)
     // first get the existing document and than merge the updated changes and save the new document
     const doc = yield eClient.get({ index: ES_PROJECT_INDEX, type: ES_PROJECT_TYPE, id: data.original.id });
     const merged = _.merge(doc._source, data.updated);        // eslint-disable-line no-underscore-dangle
+    // TEMPORARY FIX: should fix ES mapping instead and reindex all the projects instead
+    if (typeof _.get(merged, 'details.taasDefinition.team.skills') !== 'string') {
+      _.set(merged, 'details.taasDefinition.team.skills', '');
+    }
     // update the merged document
     yield eClient.update({
       index: ES_PROJECT_INDEX,
@@ -173,6 +181,10 @@ async function projectUpdatedKafkaHandler(app, topic, payload) {
   try {
     const doc = await eClient.get({ index: ES_PROJECT_INDEX, type: ES_PROJECT_TYPE, id: previousValue.id });
     const merged = _.merge(doc._source, project.get({ plain: true }));        // eslint-disable-line no-underscore-dangle
+    // TEMPORARY FIX: should fix ES mapping instead and reindex all the projects instead
+    if (typeof _.get(merged, 'details.taasDefinition.team.skills') !== 'string') {
+      _.set(merged, 'details.taasDefinition.team.skills', '');
+    }
     // update the merged document
     await eClient.update({
       index: ES_PROJECT_INDEX,

--- a/src/routes/admin/project-index-create.js
+++ b/src/routes/admin/project-index-create.js
@@ -97,6 +97,10 @@ module.exports = [
         projectResponses.map((p) => {
           if (p) {
             body.push({ index: { _index: indexName, _type: docType, _id: p.id } });
+            // TEMPORARY FIX: should fix ES mapping instead and reindex all the projects instead
+            if (typeof _.get(p, 'details.taasDefinition.team.skills') !== 'string') {
+              _.set(p, 'details.taasDefinition.team.skills', '');
+            }
             body.push(p);
           }
           // dummy return


### PR DESCRIPTION
### Overview
It happens that mapping of `details.taasDefinition.team.skills` in the ES index is defined as string, while in real form it's an array with objects. So when we try to add new projects to the index, ES throws an error:
```
[mapper_parsing_exception] failed to parse [details.taasDefinition.team.skills]
{\"type\":\"illegal_argument_exception\",\"reason\":\"unknown property [id]\"}
```

### Proper solution (long)
The only proper solution would need to make a long downtime of the service:
- find all existent projects with skills as string and update them to have an array instead
- remove index with the wrong mapping and recreate it from scratch, reindex all the projects now with fixed data, so mapping for skills would be set as array, and all new taas projects would be indexed successful

### Temporary solution (fast) - implemented in this PR
As a temporary workaround we would set  `details.taasDefinition.team.skills` to an empty string if it's defined before indexing it to ES. As in the current version on the details page we show data from DB, so if we don’t have skills in ES, the project details should be still displayed good.