### PR TITLE
Fix for Issue #560 Don't return members to user without enough permission

### DIFF
--- a/src/routes/projects/get.js
+++ b/src/routes/projects/get.js
@@ -3,6 +3,7 @@ import config from 'config';
 import { middleware as tcMiddleware } from 'tc-core-library-js';
 import models from '../../models';
 import util from '../../util';
+import { PERMISSION } from '../../permissions/constants';
 
 const ES_PROJECT_INDEX = config.get('elasticsearchConfig.indexName');
 const ES_PROJECT_TYPE = config.get('elasticsearchConfig.docType');
@@ -103,7 +104,8 @@ const retrieveProjectFromES = (projectId, req) => {
   fields = fields ? fields.split(',') : [];
   fields = util.parseFields(fields, {
     projects: PROJECT_ATTRIBUTES,
-    project_members: util.addUserDetailsFieldsIfAllowed(PROJECT_MEMBER_ATTRIBUTES_ES, req),
+    project_members: util.hasPermissionByReq(PERMISSION.READ_PROJECT_MEMBER, req)
+      ? util.addUserDetailsFieldsIfAllowed(PROJECT_MEMBER_ATTRIBUTES_ES, req) : null,
     project_member_invites: PROJECT_MEMBER_INVITE_ATTRIBUTES,
     project_phases: PROJECT_PHASE_ATTRIBUTES,
     project_phases_products: PROJECT_PHASE_PRODUCTS_ATTRIBUTES,
@@ -143,7 +145,9 @@ const retrieveProjectFromDB = (projectId, req) => {
         return Promise.reject(apiErr);
       }
         // check context for project members
-      project.members = _.map(req.context.currentProjectMembers, m => _.pick(m, fields.project_members));
+      if (util.hasPermissionByReq(PERMISSION.READ_PROJECT_MEMBER, req)) {
+        project.members = _.map(req.context.currentProjectMembers, m => _.pick(m, fields.project_members));
+      }
         // check if attachments field was requested
       if (!req.query.fields || _.indexOf(req.query.fields, 'attachments') > -1) {
         return util.getProjectAttachments(req, project.id);

--- a/src/routes/projects/get.spec.js
+++ b/src/routes/projects/get.spec.js
@@ -268,7 +268,7 @@ describe('GET Project', () => {
               should.not.exist(resJson.billingAccountId);
               should.exist(resJson.name);
               resJson.status.should.be.eql('draft');
-              resJson.members.should.have.lengthOf(2);
+              should.not.exist(resJson.members);
               done();
             }
           });

--- a/src/routes/projects/list.js
+++ b/src/routes/projects/list.js
@@ -493,7 +493,8 @@ const retrieveProjectsFromDB = (req, criteria, sort, ffields) => {
   // make sure project.id is part of fields
   if (_.indexOf(fields.projects, 'id') < 0) fields.projects.push('id');
   const retrieveAttachments = !req.query.fields || req.query.fields.indexOf('attachments') > -1;
-  const retrieveMembers = !req.query.fields || !!fields.project_members.length;
+  const retrieveMembers = (!req.query.fields || !!fields.project_members.length)
+    && util.hasPermissionByReq(PERMISSION.READ_PROJECT_MEMBER, req);
 
   return models.Project.searchText({
     filters: criteria.filters,
@@ -551,7 +552,8 @@ const retrieveProjects = (req, criteria, sort, ffields) => {
     // parse the fields string to determine what fields are to be returned
   fields = util.parseFields(fields, {
     projects: PROJECT_ATTRIBUTES,
-    project_members: util.addUserDetailsFieldsIfAllowed(PROJECT_MEMBER_ATTRIBUTES_ES, req),
+    project_members: util.hasPermissionByReq(PERMISSION.READ_PROJECT_MEMBER, req) ?
+      util.addUserDetailsFieldsIfAllowed(PROJECT_MEMBER_ATTRIBUTES_ES, req) : null,
     project_member_invites: PROJECT_MEMBER_INVITE_ATTRIBUTES,
     project_phases: PROJECT_PHASE_ATTRIBUTES,
     project_phases_products: PROJECT_PHASE_PRODUCTS_ATTRIBUTES,

--- a/src/routes/projects/list.spec.js
+++ b/src/routes/projects/list.spec.js
@@ -1182,12 +1182,11 @@ describe('LIST Project', () => {
     });
 
     describe('URL Query fields', () => {
-      it(`should not include project members when "fields" query param is not defined (to non-admin users)
-      without READ_PROJECT_MEMBER permission`, (done) => {
+      it('should not return "email" for project members when "fields" query param is not defined (to non-admin users)', (done) => {
         request(server)
         .get('/v5/projects/')
         .set({
-          Authorization: `Bearer ${testUtil.jwts.member2}`,
+          Authorization: `Bearer ${testUtil.jwts.member}`,
         })
         .expect('Content-Type', /json/)
         .expect(200)
@@ -1198,19 +1197,18 @@ describe('LIST Project', () => {
             const resJson = res.body;
             should.exist(resJson);
             resJson.should.have.lengthOf(1);
-            should.not.exist(resJson[0].members);
+            resJson[0].members[0].should.not.have.property('email');
             done();
           }
         });
       });
 
 
-      it(`should not include project members even if it's listed in "fields" query param (to non-admin users)
-      without READ_PROJECT_MEMBER permission`, (done) => {
+      it('should not return "email" for project members even if it\'s listed in "fields" query param (to non-admin users)', (done) => {
         request(server)
         .get('/v5/projects/?fields=members.email,members.id')
         .set({
-          Authorization: `Bearer ${testUtil.jwts.member2}`,
+          Authorization: `Bearer ${testUtil.jwts.member}`,
         })
         .expect('Content-Type', /json/)
         .expect(200)
@@ -1221,7 +1219,7 @@ describe('LIST Project', () => {
             const resJson = res.body;
             should.exist(resJson);
             resJson.should.have.lengthOf(1);
-            should.not.exist(resJson[0].members);
+            resJson[0].members[0].should.not.have.property('email');
             done();
           }
         });


### PR DESCRIPTION
Only return members with project object in these GET /projects and GET /projects/{id} endpoints if user has permission READ_PROJECT_MEMBER.