### PR TITLE
PM-588 copilot requests

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -244,7 +244,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: "#/definitions/ErrorModel"
-  "/projects/{projectId}/copilots/request":
+  "/projects/{projectId}/copilots/requests":
     post:
       tags:
         - projects copilot request
@@ -279,7 +279,7 @@ paths:
     get:
       tags:
         - projects copilot request
-      operationId: getCopilotRequest
+      operationId: getCopilotRequests
       security:
         - Bearer: []
       description: "Retrieve a list of copilot requests."
@@ -311,7 +311,34 @@ paths:
           description: "Internal Server Error"
           schema:
             $ref: "#/definitions/ErrorModel"
-  "/projects/{projectId}/copilots/request/{copilotRequestId}/approve":
+  "/projects/{projectId}/copilots/requests/{copilotRequestId}":
+    get:
+      tags:
+        - projects copilot request
+      operationId: getCopilotRequest
+      security:
+        - Bearer: []
+      description: "Retrieve a specific copilot request."
+      parameters:
+        - $ref: "#/parameters/copilotRequestIdParam"
+      responses:
+        "200":
+          description: "The copilot request"
+          schema:
+            $ref: "#/definitions/Copilot"
+        "401":
+          description: "Unauthorized"
+          schema:
+            $ref: "#/definitions/ErrorModel"
+        "403":
+          description: "Forbidden - User does not have permission"
+          schema:
+            $ref: "#/definitions/ErrorModel"
+        "500":
+          description: "Internal Server Error"
+          schema:
+            $ref: "#/definitions/ErrorModel"
+  "/projects/{projectId}/copilots/requests/{copilotRequestId}/approve":
     post:
       tags:
         - projects copilot request

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -244,6 +244,42 @@ paths:
           description: Internal Server Error
           schema:
             $ref: "#/definitions/ErrorModel"
+  "/projects/copilots/requests":
+    get:
+      tags:
+        - projects copilot request
+      operationId: getAllCopilotRequests
+      security:
+        - Bearer: []
+      description: "Retrieve a list of copilot requests."
+      parameters:
+        - name: sort
+          required: false
+          type: string
+          enum:
+            - createdAt asc
+            - createdAt desc
+          in: query
+          description: Sorting criteria for the requests. Default is 'createdAt desc'.
+      responses:
+        "200":
+          description: "List of copilot requests"
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Copilot"
+        "401":
+          description: "Unauthorized"
+          schema:
+            $ref: "#/definitions/ErrorModel"
+        "403":
+          description: "Forbidden - User does not have permission"
+          schema:
+            $ref: "#/definitions/ErrorModel"
+        "500":
+          description: "Internal Server Error"
+          schema:
+            $ref: "#/definitions/ErrorModel"
   "/projects/{projectId}/copilots/requests":
     post:
       tags:

--- a/src/routes/copilotRequest/approveRequest.js
+++ b/src/routes/copilotRequest/approveRequest.js
@@ -4,10 +4,13 @@ import Joi from 'joi';
 
 import util from '../../util';
 import { PERMISSION } from '../../permissions/constants';
+import { COPILOT_OPPORTUNITY_TYPE } from '../../constants';
 import approveRequest from './approveRequest.service';
 
 const addCopilotOportunityValidations = {
-  body: Joi.object().empty(),
+  body: Joi.object().keys({
+    type: Joi.string().valid(_.values(COPILOT_OPPORTUNITY_TYPE)).required(),
+  }),
 };
 
 module.exports = [

--- a/src/routes/copilotRequest/get.js
+++ b/src/routes/copilotRequest/get.js
@@ -19,25 +19,15 @@ module.exports = [
     const isAdmin = util.hasRoles(req, ADMIN_ROLES);
 
     const userId = req.authUser.userId;
-    const projectId = _.parseInt(req.params.projectId);
-
-    let sort = req.query.sort ? decodeURIComponent(req.query.sort) : 'createdAt desc';
-    if (sort.indexOf(' ') === -1) {
-      sort += ' asc';
-    }
-    const sortableProps = ['createdAt asc', 'createdAt desc'];
-    if (_.indexOf(sortableProps, sort) < 0) {
-      return util.handleError('Invalid sort criteria', null, req, next);
-    }
-    const sortParams = sort.split(' ');
+    const copilotRequestId = _.parseInt(req.params.copilotRequestId);
 
     // Admin can see all requests and the PM can only see requests created by them
     const whereCondition = _.assign({},
       isAdmin ? {} : { createdBy: userId },
-      projectId ? { projectId } : {},
+      { id: copilotRequestId },
     );
 
-    return models.CopilotRequest.findAll({
+    return models.CopilotRequest.findOne({
       where: whereCondition,
       include: [
         {
@@ -45,11 +35,10 @@ module.exports = [
           as: 'copilotOpportunity',
         },
       ],
-      order: [[sortParams[0], sortParams[1]]],
     })
-      .then(copilotRequests => res.json(copilotRequests))
+      .then(copilotRequest => res.json(copilotRequest))
       .catch((err) => {
-        util.handleError('Error fetching copilot requests', err, req, next);
+        util.handleError(`Error fetching copilot request ${copilotRequestId}`, err, req, next);
       });
   },
 ];

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -379,10 +379,14 @@ router.route('/v5/projects/:projectId(\\d+)/settings')
   .post(require('./projectSettings/create'));
 
 // Project Copilot Request
-router.route('/v5/projects/:projectId(\\d+)/copilots/request')
+router.route('/v5/projects/copilots/requests')
+  .get(require('./copilotRequest/list'));
+router.route('/v5/projects/copilots/requests/:copilotRequestId(\\d+)')
+  .get(require('./copilotRequest/get'));
+router.route('/v5/projects/:projectId(\\d+)/copilots/requests')
   .get(require('./copilotRequest/list'))
   .post(require('./copilotRequest/create'));
-router.route('/v5/projects/:projectId(\\d+)/copilots/request/:copilotRequestId(\\d+)/approve')
+router.route('/v5/projects/:projectId(\\d+)/copilots/requests/:copilotRequestId(\\d+)/approve')
   .post(require('./copilotRequest/approveRequest'));
 
 // Project Estimation Items


### PR DESCRIPTION
- Add new endpoint: - get copilot request by id
- updated the path for get copilot requests to allow getting all requests without specifying projectId