### PR TITLE
PM-1068 refactor: allow PMs to view all copilot requests

### DIFF
--- a/src/routes/copilotRequest/list.js
+++ b/src/routes/copilotRequest/list.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 
 import models from '../../models';
-import { ADMIN_ROLES } from '../../constants';
 import util from '../../util';
 import { PERMISSION } from '../../permissions/constants';
 
@@ -16,9 +15,6 @@ module.exports = [
       return next(err);
     }
 
-    const isAdmin = util.hasRoles(req, ADMIN_ROLES);
-
-    const userId = req.authUser.userId;
     const projectId = _.parseInt(req.params.projectId);
 
     let sort = req.query.sort ? decodeURIComponent(req.query.sort) : 'createdAt desc';
@@ -31,11 +27,7 @@ module.exports = [
     }
     const sortParams = sort.split(' ');
 
-    // Admin can see all requests and the PM can only see requests created by them
-    const whereCondition = _.assign({},
-      isAdmin ? {} : { createdBy: userId },
-      projectId ? { projectId } : {},
-    );
+    const whereCondition = projectId ? { projectId } : {};
 
     return models.CopilotRequest.findAll({
       where: whereCondition,


### PR DESCRIPTION
The project managers (PMs) can now see all copilot requests

https://topcoder.atlassian.net/browse/PM-1068

