### PR TITLE
fix(PM-1368, PM-1394): group by active and then sort by createdAt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ workflows:
           context : org-global
           filters:
             branches:
-              only: ['develop', 'migration-setup', 'pm-1468']
+              only: ['develop', 'migration-setup', 'pm-1368']
       - deployProd:
           context : org-global
           filters:

--- a/src/routes/copilotOpportunity/list.js
+++ b/src/routes/copilotOpportunity/list.js
@@ -34,7 +34,10 @@ module.exports = [
           attributes: ['name'],
         },
       ],
-      order: [[sortParams[0], sortParams[1]]],
+      order: [
+        [models.Sequelize.literal(`CASE WHEN status = 'active' THEN 0 ELSE 1 END`), 'ASC'],
+        [sortParams[0], sortParams[1]]
+      ],
       limit,
       offset,
     })

--- a/src/routes/copilotOpportunity/list.js
+++ b/src/routes/copilotOpportunity/list.js
@@ -35,7 +35,7 @@ module.exports = [
         },
       ],
       order: [
-        [models.Sequelize.literal(`CASE WHEN status = 'active' THEN 0 ELSE 1 END`), 'ASC'],
+        [models.Sequelize.literal(`CASE WHEN "CopilotOpportunity"."status" = 'active' THEN 0 ELSE 1 END`), 'ASC'],
         [sortParams[0], sortParams[1]]
       ],
       limit,

--- a/src/routes/copilotRequest/approveRequest.service.js
+++ b/src/routes/copilotRequest/approveRequest.service.js
@@ -49,7 +49,6 @@ module.exports = (req, data, existingTransaction) => {
                 },
               })
               .then((existingCopilotOpportunityOfSameType) => {
-                req.log.debug(existingCopilotOpportunityOfSameType, 'askdjlasd');
                 if (existingCopilotOpportunityOfSameType) {
                   const err = new Error('There\'s an opportunity of same type already!');
                   _.assign(err, {

--- a/src/routes/copilotRequest/approveRequest.service.js
+++ b/src/routes/copilotRequest/approveRequest.service.js
@@ -5,6 +5,7 @@ import models from '../../models';
 import { CONNECT_NOTIFICATION_EVENT, COPILOT_REQUEST_STATUS, TEMPLATE_IDS, USER_ROLE } from '../../constants';
 import util from '../../util';
 import { createEvent } from '../../services/busApi';
+import { Op } from 'sequelize';
 
 const resolveTransaction = (transaction, callback) => {
   if (transaction) {
@@ -42,9 +43,13 @@ module.exports = (req, data, existingTransaction) => {
                 where: {
                   projectId,
                   type: data.type,
+                  status: {
+                    [Op.notIn]: [COPILOT_REQUEST_STATUS.CANCELED],
+                  }
                 },
               })
               .then((existingCopilotOpportunityOfSameType) => {
+                req.log.debug(existingCopilotOpportunityOfSameType, 'askdjlasd');
                 if (existingCopilotOpportunityOfSameType) {
                   const err = new Error('There\'s an opportunity of same type already!');
                   _.assign(err, {

--- a/src/routes/copilotRequest/create.js
+++ b/src/routes/copilotRequest/create.js
@@ -77,6 +77,7 @@ module.exports = [
               },
             },
           }).then((copilotRequest) => {
+            req.log.info(copilotRequest, 'copilotRequest')
             if (copilotRequest && copilotRequest.data.projectType === data.data.projectType) {
               const err = new Error('There\'s a request of same type already!');
               _.assign(err, {

--- a/src/routes/copilotRequest/create.js
+++ b/src/routes/copilotRequest/create.js
@@ -77,7 +77,6 @@ module.exports = [
               },
             },
           }).then((copilotRequest) => {
-            req.log.info(copilotRequest, 'copilotRequest')
             if (copilotRequest && copilotRequest.data.projectType === data.data.projectType) {
               const err = new Error('There\'s a request of same type already!');
               _.assign(err, {


### PR DESCRIPTION
## What's in this PR?

- Group by active and then sort by createdAt
- Allow admins to create a new copilot request if the already created request for the same project plus same type is canceled.

Ticket link - https://topcoder.atlassian.net/browse/PM-1368, https://topcoder.atlassian.net/browse/PM-1394

