### PR TITLE
PM-1314 Make grouping by status optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ workflows:
           context : org-global
           filters:
             branches:
-              only: ['develop', 'migration-setup', 'pm-1510']
+              only: ['develop', 'migration-setup', 'PM-1314']
       - deployProd:
           context : org-global
           filters:

--- a/src/routes/copilotOpportunity/list.js
+++ b/src/routes/copilotOpportunity/list.js
@@ -21,6 +21,25 @@ module.exports = [
     const pageSize = parseInt(req.query.pageSize, 10) || DEFAULT_PAGE_SIZE;
     const offset = (page - 1) * pageSize;
     const limit = pageSize;
+    const noGroupingByStatus = req.query.noGrouping === 'true';
+
+    const baseOrder = [];
+
+    // If grouping is enabled (default), add custom ordering based on status
+    if (!noGroupingByStatus) {
+      baseOrder.push([
+        models.Sequelize.literal(`
+          CASE
+            WHEN "CopilotOpportunity"."status" = 'active' THEN 0
+            WHEN "CopilotOpportunity"."status" = 'cancelled' THEN 1
+            WHEN "CopilotOpportunity"."status" = 'completed' THEN 2
+            ELSE 3
+          END
+        `),
+        'ASC',
+      ]);
+    }
+    baseOrder.push([sortParams[0], sortParams[1]]);
 
     return models.CopilotOpportunity.findAll({
       include: [
@@ -34,9 +53,7 @@ module.exports = [
           attributes: ['name'],
         },
       ],
-      order: [
-        [sortParams[0], sortParams[1]],
-      ],
+      order: baseOrder,
       limit,
       offset,
     })

--- a/src/routes/copilotOpportunity/list.js
+++ b/src/routes/copilotOpportunity/list.js
@@ -35,8 +35,15 @@ module.exports = [
         },
       ],
       order: [
-        [models.Sequelize.literal(`CASE WHEN "CopilotOpportunity"."status" = 'active' THEN 0 ELSE 1 END`), 'ASC'],
-        [sortParams[0], sortParams[1]]
+        [models.Sequelize.literal(`
+          CASE
+            WHEN "CopilotOpportunity"."status" = 'active' THEN 0
+            WHEN "CopilotOpportunity"."status" = 'cancelled' THEN 1
+            WHEN "CopilotOpportunity"."status" = 'completed' THEN 2
+            ELSE 3
+          END
+        `), 'ASC'],
+        [sortParams[0], sortParams[1]],
       ],
       limit,
       offset,

--- a/src/routes/copilotOpportunity/list.js
+++ b/src/routes/copilotOpportunity/list.js
@@ -35,14 +35,6 @@ module.exports = [
         },
       ],
       order: [
-        [models.Sequelize.literal(`
-          CASE
-            WHEN "CopilotOpportunity"."status" = 'active' THEN 0
-            WHEN "CopilotOpportunity"."status" = 'cancelled' THEN 1
-            WHEN "CopilotOpportunity"."status" = 'completed' THEN 2
-            ELSE 3
-          END
-        `), 'ASC'],
         [sortParams[0], sortParams[1]],
       ],
       limit,


### PR DESCRIPTION
This makes the grouping optional so that we have grouped data on copilots portal and can opt for ungrouped data on community app