### PR TITLE
PM- 1612 Copilot Applications should be visible to all with selective data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ workflows:
           context : org-global
           filters:
             branches:
-              only: ['develop', 'migration-setup', 'pm-1611_1']
+              only: ['develop', 'migration-setup', 'PM-1612']
       - deployProd:
           context : org-global
           filters:

--- a/src/routes/copilotOpportunityApply/list.js
+++ b/src/routes/copilotOpportunityApply/list.js
@@ -6,7 +6,7 @@ import util from '../../util';
 
 module.exports = [
   (req, res, next) => {
-    const canAccessAllApplications = util.hasRoles(req, ADMIN_ROLES) || util.hasProjectManagerRole(req);
+    const isAdminOrPM = util.hasRoles(req, ADMIN_ROLES) || util.hasProjectManagerRole(req);
     const opportunityId = _.parseInt(req.params.id);
 
     let sort = req.query.sort ? decodeURIComponent(req.query.sort) : 'createdAt desc';
@@ -50,7 +50,7 @@ module.exports = [
             req.log.debug(`Fetched existing active members ${JSON.stringify(members)}`);
             req.log.debug(`Applications ${JSON.stringify(copilotApplications)}`);
             const enrichedApplications = copilotApplications.map((application) => {
-              const m = members.find(member => member.userId === application.userId);
+              const member = members.find(memberItem => memberItem.userId === application.userId);
 
               // Using spread operator fails in lint check
               // While Object.assign fails silently during run time
@@ -70,8 +70,8 @@ module.exports = [
                 copilotOpportunity: application.copilotOpportunity,
               };
 
-              if (m) {
-                enriched.existingMembership = m;
+              if (member) {
+                enriched.existingMembership = member;
               }
 
               req.log.debug(`Existing member to application ${JSON.stringify(enriched)}`);
@@ -79,7 +79,7 @@ module.exports = [
               return enriched;
             });
 
-            const response = canAccessAllApplications
+            const response = isAdminOrPM
               ? enrichedApplications
               : enrichedApplications.map(app => ({
                 userId: app.userId,

--- a/src/routes/copilotOpportunityApply/list.js
+++ b/src/routes/copilotOpportunityApply/list.js
@@ -1,17 +1,12 @@
 import _ from 'lodash';
-import { middleware as tcMiddleware } from 'tc-core-library-js';
 
 import models from '../../models';
 import { ADMIN_ROLES } from '../../constants';
 import util from '../../util';
 
-const permissions = tcMiddleware.permissions;
-
 module.exports = [
-  permissions('copilotApplications.view'),
   (req, res, next) => {
     const canAccessAllApplications = util.hasRoles(req, ADMIN_ROLES) || util.hasProjectManagerRole(req);
-    const userId = req.authUser.userId;
     const opportunityId = _.parseInt(req.params.id);
 
     let sort = req.query.sort ? decodeURIComponent(req.query.sort) : 'createdAt desc';
@@ -24,17 +19,15 @@ module.exports = [
     }
     const sortParams = sort.split(' ');
 
-    // Admin can see all requests and the PM can only see requests created by them
     const whereCondition = _.assign({
       opportunityId,
     },
-    canAccessAllApplications ? {} : { createdBy: userId },
     );
 
     return models.CopilotOpportunity.findOne({
       where: {
         id: opportunityId,
-      }
+      },
     }).then((opportunity) => {
       if (!opportunity) {
         const err = new Error('No opportunity found');
@@ -51,13 +44,13 @@ module.exports = [
         ],
         order: [[sortParams[0], sortParams[1]]],
       })
-        .then(copilotApplications => {
+        .then((copilotApplications) => {
           req.log.debug(`CopilotApplications ${JSON.stringify(copilotApplications)}`);
           return models.ProjectMember.getActiveProjectMembers(opportunity.projectId).then((members) => {
             req.log.debug(`Fetched existing active members ${JSON.stringify(members)}`);
             req.log.debug(`Applications ${JSON.stringify(copilotApplications)}`);
-            const enrichedApplications = copilotApplications.map(application => {
-              const m = members.find(m => m.userId === application.userId);
+            const enrichedApplications = copilotApplications.map((application) => {
+              const m = members.find(member => member.userId === application.userId);
 
               // Using spread operator fails in lint check
               // While Object.assign fails silently during run time
@@ -86,13 +79,21 @@ module.exports = [
               return enriched;
             });
 
+            const response = canAccessAllApplications
+              ? enrichedApplications
+              : enrichedApplications.map(app => ({
+                userId: app.userId,
+                status: app.status,
+                createdAt: app.createdAt,
+              }));
+
             req.log.debug(`Enriched Applications ${JSON.stringify(enrichedApplications)}`);
-            res.status(200).send(enrichedApplications);
+            res.status(200).send(response);
           });
-        })
+        });
     })
-    .catch((err) => {
-      util.handleError('Error fetching copilot applications', err, req, next);
-    });
+      .catch((err) => {
+        util.handleError('Error fetching copilot applications', err, req, next);
+      });
   },
 ];


### PR DESCRIPTION
The API should not restrict users, instead we're adding a filter to the response later.
Admins and PMs can view the entire response and the rest of the users can view only handles, status and applied date.