### PR TITLE
PM-2648: Send copilot application emails to PMs

### DIFF
--- a/src/routes/copilotOpportunityApply/create.js
+++ b/src/routes/copilotOpportunityApply/create.js
@@ -16,6 +16,109 @@ const applyCopilotRequestValidations = {
   }),
 };
 
+/**
+ * Adds a notification recipient if the member has an email address and has not already been added.
+ *
+ * @param {Array} recipients current recipient list for the notification
+ * @param {Object} subject member or role subject with email and handle fields
+ * @returns {void} updates the recipient list in place
+ * @throws {Error} does not throw; invalid subjects are ignored
+ */
+const addEmailRecipient = (recipients, subject) => {
+  if (!subject || !subject.email) {
+    return;
+  }
+
+  const recipientExists = recipients.find(
+    item => item.email.toLowerCase() === subject.email.toLowerCase(),
+  );
+  if (recipientExists) {
+    return;
+  }
+
+  recipients.push({
+    email: subject.email,
+    handle: subject.handle,
+  });
+};
+
+/**
+ * Resolves all PM recipients and the opportunity creator for copilot application notifications.
+ *
+ * @param {Object} req express request object used for logging and downstream API request ids
+ * @param {Object} opportunity copilot opportunity receiving the application
+ * @returns {Promise<Array>} unique recipients with email and handle fields
+ * @throws {Error} does not throw; lookup failures are logged so application creation is not blocked
+ */
+const getCopilotApplicationNotificationRecipients = async (req, opportunity) => {
+  const recipients = [];
+
+  try {
+    const pmRole = await util.getRolesByRoleName(USER_ROLE.PROJECT_MANAGER, req.log, req.id);
+    if (pmRole.length > 0) {
+      const { subjects = [] } = await util.getRoleInfo(pmRole[0], req.log, req.id);
+      subjects.forEach(subject => addEmailRecipient(recipients, subject));
+    }
+  } catch (err) {
+    req.log.error(`Error resolving project manager recipients for copilot application: ${err.message}`);
+  }
+
+  try {
+    const creator = await util.getMemberDetailsByUserIds([opportunity.createdBy], req.log, req.id);
+    addEmailRecipient(recipients, creator && creator[0]);
+  } catch (err) {
+    req.log.error(`Error resolving opportunity creator recipient for copilot application: ${err.message}`);
+  }
+
+  return recipients;
+};
+
+/**
+ * Sends PM and opportunity creator notifications after a copilot applies to an opportunity.
+ *
+ * @param {Object} req express request object used for logging and downstream API request ids
+ * @param {Object} opportunity copilot opportunity receiving the application
+ * @param {Object} application newly created copilot application
+ * @returns {Promise<void>} resolves after notification bus events have been submitted
+ * @throws {Error} does not throw; notification failures are logged so the application response succeeds
+ */
+const sendCopilotApplicationNotifications = async (req, opportunity, application) => {
+  try {
+    const recipients = await getCopilotApplicationNotificationRecipients(req, opportunity);
+    if (recipients.length === 0) {
+      return;
+    }
+
+    let applicant = null;
+    try {
+      const applicantDetails = await util.getMemberDetailsByUserIds([application.userId], req.log, req.id);
+      applicant = applicantDetails && applicantDetails[0];
+    } catch (err) {
+      req.log.error(`Error resolving copilot applicant for notification payload: ${err.message}`);
+    }
+
+    const emailEventType = CONNECT_NOTIFICATION_EVENT.EXTERNAL_ACTION_EMAIL;
+    const copilotPortalUrl = config.get('copilotPortalUrl');
+    const requestData = opportunity.copilotRequest.data;
+
+    await Promise.all(recipients.map(subject => createEvent(emailEventType, {
+      data: {
+        user_name: subject.handle,
+        opportunity_details_url: `${copilotPortalUrl}/opportunity/${opportunity.id}#applications`,
+        work_manager_url: config.get('workManagerUrl'),
+        opportunity_type: getCopilotTypeLabel(requestData.projectType),
+        opportunity_title: requestData.opportunityTitle,
+        copilot_handle: applicant ? applicant.handle : '',
+      },
+      sendgrid_template_id: TEMPLATE_IDS.APPLY_COPILOT,
+      recipients: [subject.email],
+      version: 'v3',
+    }, req.log)));
+  } catch (err) {
+    req.log.error(`Error sending copilot application notifications: ${err.message}`);
+  }
+};
+
 module.exports = [
   validate(applyCopilotRequestValidations),
   async (req, res, next) => {
@@ -75,46 +178,7 @@ module.exports = [
 
       return models.CopilotApplication.create(data)
         .then(async (result) => {
-          const pmRole = await util.getRolesByRoleName(USER_ROLE.PROJECT_MANAGER, req.log, req.id);
-          const { subjects = [] } = await util.getRoleInfo(pmRole[0], req.log, req.id);
-
-          const creator = await util.getMemberDetailsByUserIds([opportunity.createdBy], req.log, req.id);
-
-          const listOfSubjects = subjects;
-          if (creator && creator[0] && creator[0].email) {
-            const isCreatorPartofSubjects = subjects.find(item => {
-              if (!item.email) {
-                return false;
-              }
-
-              return item.email.toLowerCase() === creator[0].email.toLowerCase();
-            });
-            if (!isCreatorPartofSubjects) {
-              listOfSubjects.push({
-                email: creator[0].email,
-                handle: creator[0].handle,
-              });
-            }
-          }
-          
-          const emailEventType = CONNECT_NOTIFICATION_EVENT.EXTERNAL_ACTION_EMAIL;
-          const copilotPortalUrl = config.get('copilotPortalUrl');
-          const requestData = opportunity.copilotRequest.data;
-          listOfSubjects.forEach((subject) => {
-            createEvent(emailEventType, {
-                data: {
-                  user_name: subject.handle,
-                  opportunity_details_url: `${copilotPortalUrl}/opportunity/${opportunity.id}#applications`,
-                  work_manager_url: config.get('workManagerUrl'),
-                  opportunity_type: getCopilotTypeLabel(requestData.projectType),
-                  opportunity_title: requestData.opportunityTitle,
-                },
-                sendgrid_template_id: TEMPLATE_IDS.APPLY_COPILOT,
-                recipients: [subject.email],
-                version: 'v3',
-              }, req.log);
-          });
-
+          await sendCopilotApplicationNotifications(req, opportunity, result);
           res.status(201).json(result);
           return Promise.resolve();
         })

--- a/src/routes/copilotOpportunityApply/create.spec.js
+++ b/src/routes/copilotOpportunityApply/create.spec.js
@@ -1,0 +1,132 @@
+/* eslint-disable no-unused-expressions */
+import chai from 'chai';
+import sinon from 'sinon';
+
+import models from '../../models';
+import util from '../../util';
+import busApi from '../../services/busApi';
+import {
+  CONNECT_NOTIFICATION_EVENT,
+  COPILOT_OPPORTUNITY_STATUS,
+  TEMPLATE_IDS,
+  USER_ROLE,
+} from '../../constants';
+import createHandlers from './create';
+
+chai.should();
+
+describe('Copilot Opportunity Apply create', () => {
+  let sandbox;
+  let req;
+  let res;
+  let next;
+  let opportunity;
+  let application;
+
+  const handler = createHandlers[1];
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    opportunity = {
+      id: 123,
+      status: COPILOT_OPPORTUNITY_STATUS.ACTIVE,
+      createdBy: 40051334,
+      copilotRequest: {
+        data: {
+          projectType: 'dev',
+          opportunityTitle: 'New mobile app build',
+        },
+      },
+    };
+    application = {
+      id: 456,
+      opportunityId: opportunity.id,
+      userId: 40051332,
+      notes: 'Available next week',
+    };
+    req = {
+      id: 'request-id',
+      authUser: { userId: application.userId },
+      body: { notes: application.notes },
+      log: {
+        debug: sandbox.stub(),
+        error: sandbox.stub(),
+      },
+      params: { id: `${opportunity.id}` },
+      sanitize: value => value,
+    };
+    res = {
+      status: sandbox.stub().returnsThis(),
+      json: sandbox.stub(),
+    };
+    next = sandbox.stub();
+
+    sandbox.stub(util, 'hasPermissionByReq').returns(true);
+    sandbox.stub(models.CopilotOpportunity, 'findOne').returns(Promise.resolve(opportunity));
+    sandbox.stub(models.CopilotApplication, 'findOne').returns(Promise.resolve(null));
+    sandbox.stub(models.CopilotApplication, 'create').returns(Promise.resolve(application));
+    sandbox.stub(busApi, 'createEvent').returns(Promise.resolve());
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('sends application notifications to PM role subjects and the opportunity creator', async () => {
+    sandbox.stub(util, 'getRolesByRoleName').returns(Promise.resolve([120]));
+    sandbox.stub(util, 'getRoleInfo').returns(Promise.resolve({
+      subjects: [
+        { email: 'pm1@example.com', handle: 'pm1' },
+        { email: 'CREATOR@example.com', handle: 'creator-as-pm' },
+        { handle: 'missing-email' },
+      ],
+    }));
+    sandbox.stub(util, 'getMemberDetailsByUserIds', (userIds) => {
+      if (userIds[0] === opportunity.createdBy) {
+        return Promise.resolve([{ email: 'creator@example.com', handle: 'creator' }]);
+      }
+      return Promise.resolve([{ email: 'copilot@example.com', handle: 'applicant' }]);
+    });
+
+    await handler(req, res, next);
+
+    next.notCalled.should.be.true;
+    res.status.calledWith(201).should.be.true;
+    res.json.calledWith(application).should.be.true;
+
+    busApi.createEvent.callCount.should.equal(2);
+    const recipients = busApi.createEvent.getCalls()
+      .map(call => call.args[1].recipients[0])
+      .sort();
+    recipients.should.deep.equal(['CREATOR@example.com', 'pm1@example.com'].sort());
+
+    busApi.createEvent.getCalls().forEach((call) => {
+      call.args[0].should.equal(CONNECT_NOTIFICATION_EVENT.EXTERNAL_ACTION_EMAIL);
+      call.args[1].sendgrid_template_id.should.equal(TEMPLATE_IDS.APPLY_COPILOT);
+      call.args[1].data.opportunity_details_url.should.contain('/opportunity/123#applications');
+      call.args[1].data.opportunity_title.should.equal('New mobile app build');
+      call.args[1].data.copilot_handle.should.equal('applicant');
+    });
+    util.getRolesByRoleName.calledWith(USER_ROLE.PROJECT_MANAGER).should.be.true;
+  });
+
+  it('still notifies the creator when PM role lookup fails', async () => {
+    sandbox.stub(util, 'getRolesByRoleName', () => Promise.reject(new Error('role service down')));
+    sandbox.stub(util, 'getRoleInfo').returns(Promise.resolve({ subjects: [] }));
+    sandbox.stub(util, 'getMemberDetailsByUserIds', (userIds) => {
+      if (userIds[0] === opportunity.createdBy) {
+        return Promise.resolve([{ email: 'creator@example.com', handle: 'creator' }]);
+      }
+      return Promise.resolve([{ email: 'copilot@example.com', handle: 'applicant' }]);
+    });
+
+    await handler(req, res, next);
+
+    next.notCalled.should.be.true;
+    res.status.calledWith(201).should.be.true;
+    busApi.createEvent.calledOnce.should.be.true;
+    busApi.createEvent.firstCall.args[1].recipients.should.deep.equal(['creator@example.com']);
+    req.log.error.called.should.be.true;
+  });
+});


### PR DESCRIPTION
What was broken
PM users and opportunity creators could miss email notifications when a copilot applied for an opportunity.

Root cause
The apply handler resolved PM role subjects and the opportunity creator inline with application creation, so recipient lookup failures could suppress all application emails. It also reused the role subject list directly and did not wait for email bus event submissions.

What was changed
Added a dedicated notification flow that resolves PM role subjects and the opportunity creator, filters recipients without emails, deduplicates recipients by email, logs lookup or send failures without blocking the application response, includes the applicant handle, and awaits external email bus event submissions.

Any added/updated tests
Added unit coverage for PM and creator notification events, including the fallback path where the creator is still notified if PM role lookup fails.

Validation run:
- NODE_ENV=test DB_SCHEMA_NAME=public node node_modules/mocha/bin/_mocha --timeout 10000 --require babel-core/register --require ./src/tests src/routes/copilotOpportunityApply/create.spec.js --exit
- NODE_ENV=test DB_SCHEMA_NAME=public node node_modules/eslint/bin/eslint.js src/routes/copilotOpportunityApply/create.js src/routes/copilotOpportunityApply/create.spec.js
- NODE_ENV=test DB_SCHEMA_NAME=public npm run build

Full npm test was attempted with DB_SCHEMA_NAME=public, but it stops in npm run lint on pre-existing unrelated lint errors across legacy copilot/project files before reaching DB, ES, or mocha.
